### PR TITLE
Fix back to search link on result pages

### DIFF
--- a/app/src/app/race/[slug]/result/[id]/page.tsx
+++ b/app/src/app/race/[slug]/result/[id]/page.tsx
@@ -61,7 +61,7 @@ export default async function ResultPage({ params }: PageProps) {
 
   return (
     <main className="max-w-4xl mx-auto px-4 py-8">
-      <Link href={`/race/${slug}`} className="text-blue-600 hover:underline text-sm mb-6 inline-block">
+      <Link href="/" className="text-blue-600 hover:underline text-sm mb-6 inline-block">
         &larr; Back to search
       </Link>
 


### PR DESCRIPTION
## Summary
- The "Back to search" link on result pages pointed to the race-specific search page (`/race/[slug]`). Now that the landing page has cross-race search, it should navigate to `/` instead.

Closes #1

## Test plan
- [ ] Navigate to a result page (e.g. `/race/im703-new-york-2025/result/176`)
- [ ] Click "Back to search" and verify it goes to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)