### PR TITLE
Add dark theme and sticky header

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 @theme inline {

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Header from "@/components/Header";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -26,8 +27,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-50`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[var(--background)]`}
       >
+        <Header />
         {children}
       </body>
     </html>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -8,13 +8,13 @@ export default function Home() {
   return (
     <main className="min-h-screen flex flex-col items-center justify-center px-4">
       <div className="text-center mb-8">
-        <h1 className="text-5xl font-bold text-gray-900 mb-2">TriTimes</h1>
-        <p className="text-lg text-gray-600">
+        <h1 className="text-5xl font-bold text-white mb-2">TriTimes</h1>
+        <p className="text-lg text-gray-400">
           See how you performed relative to the field
         </p>
       </div>
       <GlobalSearchBar entries={entries} />
-      <Link href="/races" className="text-sm text-gray-400 hover:text-gray-600 mt-6">
+      <Link href="/races" className="text-sm text-gray-500 hover:text-gray-300 mt-6">
         Browse all races
       </Link>
     </main>

--- a/app/src/app/race/[slug]/page.tsx
+++ b/app/src/app/race/[slug]/page.tsx
@@ -1,5 +1,4 @@
 import { notFound } from "next/navigation";
-import Link from "next/link";
 import { getRaces, getRaceBySlug, getSearchIndex } from "@/lib/data";
 import SearchBar from "@/components/SearchBar";
 
@@ -21,14 +20,11 @@ export default async function RaceSearchPage({ params }: PageProps) {
   return (
     <main className="min-h-screen flex flex-col items-center justify-center px-4">
       <div className="text-center mb-8">
-        <Link href="/" className="text-blue-600 hover:underline text-sm mb-4 inline-block">
-          &larr; All races
-        </Link>
-        <h1 className="text-5xl font-bold text-gray-900 mb-2">TriTimes</h1>
-        <p className="text-lg text-gray-600">
+        <h1 className="text-5xl font-bold text-white mb-2">TriTimes</h1>
+        <p className="text-lg text-gray-400">
           {race.name} — {entries.length} finishers
         </p>
-        <p className="text-sm text-gray-400 mt-1">
+        <p className="text-sm text-gray-500 mt-1">
           See how you performed relative to the field
         </p>
       </div>

--- a/app/src/app/race/[slug]/result/[id]/page.tsx
+++ b/app/src/app/race/[slug]/result/[id]/page.tsx
@@ -56,13 +56,13 @@ export default async function ResultPage({ params }: PageProps) {
 
   return (
     <main className="max-w-4xl mx-auto px-4 py-8">
-      <Link href="/" className="text-blue-600 hover:underline text-sm mb-6 inline-block">
+      <Link href={`/race/${slug}`} className="text-blue-400 hover:underline text-sm mb-6 inline-block">
         &larr; Back to search
       </Link>
 
       <header className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900">{athlete.fullName}</h1>
-        <p className="text-gray-600 mt-1">
+        <h1 className="text-3xl font-bold text-white">{athlete.fullName}</h1>
+        <p className="text-gray-400 mt-1">
           {race.name} &middot; Bib #{athlete.bib} &middot; {athlete.ageGroup} &middot;{" "}
           {[athlete.city, athlete.state, athlete.country].filter(Boolean).join(", ")}
         </p>

--- a/app/src/app/races/page.tsx
+++ b/app/src/app/races/page.tsx
@@ -6,11 +6,7 @@ export default function RacesPage() {
 
   return (
     <main className="max-w-4xl mx-auto px-4 py-8">
-      <Link href="/" className="text-blue-600 hover:underline text-sm mb-6 inline-block">
-        &larr; Home
-      </Link>
-
-      <h1 className="text-3xl font-bold text-gray-900 mb-6">All Races</h1>
+      <h1 className="text-3xl font-bold text-white mb-6">All Races</h1>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {races.map((race) => {
@@ -19,11 +15,11 @@ export default function RacesPage() {
             <Link
               key={race.slug}
               href={`/race/${race.slug}`}
-              className="block p-6 border border-gray-200 rounded-lg hover:border-blue-400 hover:shadow-md transition-all"
+              className="block p-6 border border-gray-700 rounded-lg hover:border-blue-400 hover:shadow-md transition-all bg-gray-900"
             >
-              <h2 className="text-xl font-semibold text-gray-900">{race.name}</h2>
-              <p className="text-sm text-gray-500 mt-1">{race.location}</p>
-              <p className="text-sm text-gray-400 mt-1">
+              <h2 className="text-xl font-semibold text-white">{race.name}</h2>
+              <p className="text-sm text-gray-400 mt-1">{race.location}</p>
+              <p className="text-sm text-gray-500 mt-1">
                 {race.date} &middot; {count} finishers
               </p>
             </Link>

--- a/app/src/components/DisciplineSection.tsx
+++ b/app/src/components/DisciplineSection.tsx
@@ -28,10 +28,10 @@ export default function DisciplineSection({
   const color = COLORS[discipline] || "#6b7280";
 
   return (
-    <section className="bg-white rounded-xl border border-gray-200 p-6">
+    <section className="bg-gray-900 rounded-xl border border-gray-700 p-6">
       <div className="flex items-center gap-3 mb-4">
-        <h2 className="text-xl font-bold text-gray-900">{discipline}</h2>
-        <span className="text-lg text-gray-600">{time}</span>
+        <h2 className="text-xl font-bold text-white">{discipline}</h2>
+        <span className="text-lg text-gray-400">{time}</span>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <Histogram data={overallData} color={color} label="Overall Field" />

--- a/app/src/components/GlobalSearchBar.tsx
+++ b/app/src/components/GlobalSearchBar.tsx
@@ -69,20 +69,20 @@ export default function GlobalSearchBar({ entries }: { entries: GlobalSearchEntr
         onKeyDown={handleKeyDown}
         onFocus={() => matches.length > 0 && setIsOpen(true)}
         placeholder="Search athlete name..."
-        className="w-full px-4 py-3 text-lg border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        className="w-full px-4 py-3 text-lg border border-gray-700 rounded-lg bg-gray-900 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
       />
       {isOpen && (
-        <ul className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-80 overflow-y-auto">
+        <ul className="absolute z-10 w-full mt-1 bg-gray-900 border border-gray-700 rounded-lg shadow-lg max-h-80 overflow-y-auto">
           {matches.map((entry, i) => (
             <li
               key={`${entry.raceSlug}-${entry.id}`}
               onClick={() => handleSelect(entry)}
-              className={`px-4 py-3 cursor-pointer border-b border-gray-100 last:border-b-0 ${
-                i === selectedIndex ? "bg-blue-50" : "hover:bg-gray-50"
+              className={`px-4 py-3 cursor-pointer border-b border-gray-800 last:border-b-0 ${
+                i === selectedIndex ? "bg-gray-800" : "hover:bg-gray-800"
               }`}
             >
-              <div className="font-medium text-gray-900">{entry.fullName}</div>
-              <div className="text-sm text-gray-500">
+              <div className="font-medium text-white">{entry.fullName}</div>
+              <div className="text-sm text-gray-400">
                 {entry.raceName} &middot; {entry.ageGroup} &middot; {entry.country}
               </div>
             </li>

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+export default function Header() {
+  return (
+    <header className="sticky top-0 z-50 bg-gray-900/80 backdrop-blur-sm border-b border-gray-800">
+      <div className="max-w-4xl mx-auto px-4 h-14 flex items-center justify-between">
+        <Link href="/" className="text-lg font-bold text-white hover:text-gray-300 transition-colors">
+          TriTimes
+        </Link>
+        <nav className="flex items-center gap-6">
+          <Link href="/races" className="text-sm text-gray-400 hover:text-white transition-colors">
+            Races
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/app/src/components/Histogram.tsx
+++ b/app/src/components/Histogram.tsx
@@ -35,7 +35,7 @@ export default function Histogram({ data, color, label }: Props) {
   return (
     <div>
       <div className="flex items-center justify-between mb-2">
-        <span className="text-sm font-medium text-gray-600">{label}</span>
+        <span className="text-sm font-medium text-gray-400">{label}</span>
         <span className="text-sm font-semibold" style={{ color }}>
           Faster than {data.athletePercentile}%
         </span>
@@ -44,13 +44,14 @@ export default function Histogram({ data, color, label }: Props) {
         <BarChart data={data.bins} margin={{ top: 5, right: 10, bottom: 5, left: 0 }}>
           <XAxis
             dataKey="label"
-            tick={{ fontSize: 11 }}
+            tick={{ fontSize: 11, fill: "#9ca3af" }}
             interval={step - 1}
           />
-          <YAxis tick={{ fontSize: 11 }} width={40} />
+          <YAxis tick={{ fontSize: 11, fill: "#9ca3af" }} width={40} />
           <Tooltip
             formatter={(value: number | undefined) => [value ?? 0, "Athletes"]}
             labelFormatter={(label) => `Time: ${label}`}
+            contentStyle={{ backgroundColor: "#1f2937", border: "1px solid #374151", color: "#ededed" }}
           />
           <ReferenceLine
             x={data.bins.find((b) => b.isAthlete)?.label}
@@ -62,7 +63,7 @@ export default function Histogram({ data, color, label }: Props) {
             {data.bins.map((bin, i) => (
               <Cell
                 key={i}
-                fill={bin.isAthlete ? color : "#d1d5db"}
+                fill={bin.isAthlete ? color : "#374151"}
               />
             ))}
           </Bar>

--- a/app/src/components/ResultCard.tsx
+++ b/app/src/components/ResultCard.tsx
@@ -6,10 +6,10 @@ interface Props {
 
 export default function ResultCard({ label, value, subtext }: Props) {
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4 text-center">
-      <div className="text-sm text-gray-500 mb-1">{label}</div>
-      <div className="text-2xl font-bold text-gray-900">{value}</div>
-      {subtext && <div className="text-xs text-gray-400 mt-1">{subtext}</div>}
+    <div className="bg-gray-900 rounded-lg border border-gray-700 p-4 text-center">
+      <div className="text-sm text-gray-400 mb-1">{label}</div>
+      <div className="text-2xl font-bold text-white">{value}</div>
+      {subtext && <div className="text-xs text-gray-500 mt-1">{subtext}</div>}
     </div>
   );
 }

--- a/app/src/components/SearchBar.tsx
+++ b/app/src/components/SearchBar.tsx
@@ -69,20 +69,20 @@ export default function SearchBar({ entries, raceSlug }: { entries: SearchEntry[
         onKeyDown={handleKeyDown}
         onFocus={() => matches.length > 0 && setIsOpen(true)}
         placeholder="Search athlete name..."
-        className="w-full px-4 py-3 text-lg border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        className="w-full px-4 py-3 text-lg border border-gray-700 rounded-lg bg-gray-900 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
       />
       {isOpen && (
-        <ul className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-80 overflow-y-auto">
+        <ul className="absolute z-10 w-full mt-1 bg-gray-900 border border-gray-700 rounded-lg shadow-lg max-h-80 overflow-y-auto">
           {matches.map((entry, i) => (
             <li
               key={entry.id}
               onClick={() => handleSelect(entry)}
-              className={`px-4 py-3 cursor-pointer border-b border-gray-100 last:border-b-0 ${
-                i === selectedIndex ? "bg-blue-50" : "hover:bg-gray-50"
+              className={`px-4 py-3 cursor-pointer border-b border-gray-800 last:border-b-0 ${
+                i === selectedIndex ? "bg-gray-800" : "hover:bg-gray-800"
               }`}
             >
-              <div className="font-medium text-gray-900">{entry.fullName}</div>
-              <div className="text-sm text-gray-500">
+              <div className="font-medium text-white">{entry.fullName}</div>
+              <div className="text-sm text-gray-400">
                 {entry.ageGroup} &middot; {entry.country}
               </div>
             </li>


### PR DESCRIPTION
## Summary
- Switch entire UI from light to dark theme (dark backgrounds, light text, dark-styled search dropdowns, histogram tooltips and bars)
- Add sticky header component with TriTimes logo and Races nav link, replacing ad-hoc back links on races and race search pages
- Keep contextual "Back to search" link on athlete result pages

## Test plan
- [ ] `npm run build` passes with no errors
- [ ] Visually verify dark theme on all pages (home, races, race search, athlete result)
- [ ] Verify sticky header stays visible on scroll
- [ ] Verify header links navigate correctly
- [ ] Check search dropdowns render with dark styling
- [ ] Check histogram bars and tooltips use dark colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)