### PR TITLE
Add hero section to landing page

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,22 +1,67 @@
 import Link from "next/link";
-import { getGlobalSearchIndex } from "@/lib/data";
+import { getGlobalSearchIndex, getRaces } from "@/lib/data";
 import GlobalSearchBar from "@/components/GlobalSearchBar";
 
 export default function Home() {
   const entries = getGlobalSearchIndex();
+  const races = getRaces();
+  const athleteCount = new Set(entries.map((e) => e.fullName)).size;
 
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center px-4">
-      <div className="text-center mb-8">
-        <h1 className="text-5xl font-bold text-white mb-2">TriTimes</h1>
-        <p className="text-lg text-gray-400">
-          See how you performed relative to the field
-        </p>
-      </div>
-      <GlobalSearchBar entries={entries} />
-      <Link href="/races" className="text-sm text-gray-500 hover:text-gray-300 mt-6">
-        Browse all races
-      </Link>
+    <main className="min-h-screen">
+      {/* Hero section */}
+      <section className="relative overflow-hidden">
+        {/* Background gradient */}
+        <div className="absolute inset-0 bg-gradient-to-br from-blue-950 via-[#0a0a0a] to-gray-900" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(59,130,246,0.15),transparent_60%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_right,rgba(168,85,247,0.08),transparent_50%)]" />
+
+        <div className="relative z-10 flex flex-col items-center justify-center text-center px-4 pt-28 pb-20">
+          <h1 className="text-6xl sm:text-7xl font-bold text-white tracking-tight mb-4">
+            Race. Compare.{" "}
+            <span className="bg-gradient-to-r from-blue-400 to-blue-500 bg-clip-text text-transparent">
+              Improve.
+            </span>
+          </h1>
+          <p className="text-lg sm:text-xl text-gray-400 max-w-xl mb-10 leading-relaxed">
+            Explore your IronMan &amp; 70.3 results with full field distributions.
+            See where you stand in swim, bike, run, and overall.
+          </p>
+
+          <div className="w-full max-w-lg mb-4">
+            <GlobalSearchBar entries={entries} />
+          </div>
+
+          <Link
+            href="/races"
+            className="text-sm text-gray-500 hover:text-gray-300 transition-colors"
+          >
+            or browse all races &rarr;
+          </Link>
+        </div>
+      </section>
+
+      {/* Stats strip */}
+      <section className="border-t border-gray-800 bg-gray-900/50">
+        <div className="max-w-4xl mx-auto px-4 py-10 grid grid-cols-3 gap-4 text-center">
+          <div>
+            <div className="text-3xl font-bold text-white">{races.length}</div>
+            <div className="text-sm text-gray-500 mt-1">Races</div>
+          </div>
+          <div>
+            <div className="text-3xl font-bold text-white">
+              {athleteCount.toLocaleString()}
+            </div>
+            <div className="text-sm text-gray-500 mt-1">Athletes</div>
+          </div>
+          <div>
+            <div className="text-3xl font-bold text-white">
+              {entries.length.toLocaleString()}
+            </div>
+            <div className="text-sm text-gray-500 mt-1">Results</div>
+          </div>
+        </div>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a visually compelling hero section with layered gradient background (blue/purple radial glows)
- New tagline: "Race. Compare. Improve." with gradient-highlighted text
- Stats strip below the hero showing live counts of races, athletes, and results
- Search bar and "browse all races" link remain the primary CTAs

Closes #6

## Test plan
- [ ] Verify hero section renders correctly on desktop and mobile
- [ ] Confirm search bar and "browse all races" link still function
- [ ] Check stats strip shows accurate counts from the dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)