### PR TITLE
Add visual richness to race cards

### DIFF
--- a/app/src/app/races/page.tsx
+++ b/app/src/app/races/page.tsx
@@ -1,27 +1,70 @@
 import Link from "next/link";
-import { getRaces, getAllResults } from "@/lib/data";
+import { getRaces } from "@/lib/data";
+import { getCountryFlag } from "@/lib/flags";
+
+function formatDate(iso: string): string {
+  const date = new Date(iso + "T00:00:00");
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function getDistanceInfo(slug: string): { label: string; color: string; accent: string } {
+  if (slug.startsWith("im703-")) {
+    return {
+      label: "70.3",
+      color: "bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/30",
+      accent: "border-l-blue-500",
+    };
+  }
+  return {
+    label: "140.6",
+    color: "bg-orange-500/20 text-orange-400 ring-1 ring-orange-500/30",
+    accent: "border-l-orange-500",
+  };
+}
 
 export default function RacesPage() {
   const races = getRaces();
 
   return (
-    <main className="max-w-4xl mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold text-white mb-6">All Races</h1>
+    <main className="max-w-5xl mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold text-white mb-8">All Races</h1>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {races.map((race) => {
-          const count = getAllResults(race.slug).length;
+          const distance = getDistanceInfo(race.slug);
+          const flag = getCountryFlag(race.location);
+
           return (
             <Link
               key={race.slug}
               href={`/race/${race.slug}`}
-              className="block p-6 border border-gray-700 rounded-lg hover:border-blue-400 hover:shadow-md transition-all bg-gray-900"
+              className={`group block p-5 border border-gray-700/80 border-l-4 ${distance.accent} rounded-lg bg-gray-900 transition-all duration-200 hover:border-gray-600 hover:bg-gray-800/80 hover:shadow-lg hover:shadow-black/20 hover:-translate-y-0.5`}
             >
-              <h2 className="text-xl font-semibold text-white">{race.name}</h2>
-              <p className="text-sm text-gray-400 mt-1">{race.location}</p>
-              <p className="text-sm text-gray-500 mt-1">
-                {race.date} &middot; {count} finishers
+              <div className="flex items-start justify-between gap-3">
+                <h2 className="text-lg font-semibold text-white group-hover:text-blue-300 transition-colors leading-tight">
+                  {race.name}
+                </h2>
+                <span className={`shrink-0 px-2 py-0.5 rounded-full text-xs font-bold ${distance.color}`}>
+                  {distance.label}
+                </span>
+              </div>
+
+              <p className="text-sm text-gray-400 mt-2">
+                {flag && <span className="mr-1.5">{flag}</span>}
+                {race.location}
               </p>
+
+              <div className="flex items-center gap-3 mt-3 text-xs text-gray-500">
+                <span>{formatDate(race.date)}</span>
+                <span className="text-gray-700">&middot;</span>
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-800 text-gray-400">
+                  {race.finishers.toLocaleString()} finishers
+                </span>
+              </div>
             </Link>
           );
         })}

--- a/app/src/lib/data.ts
+++ b/app/src/lib/data.ts
@@ -20,6 +20,7 @@ function loadRaces(): RaceInfo[] {
     name: e.name,
     date: e.date,
     location: e.location,
+    finishers: e.finishers,
   }));
 }
 

--- a/app/src/lib/flags.ts
+++ b/app/src/lib/flags.ts
@@ -1,0 +1,28 @@
+const COUNTRY_FLAGS: Record<string, string> = {
+  USA: "\u{1F1FA}\u{1F1F8}",
+  Canada: "\u{1F1E8}\u{1F1E6}",
+  UK: "\u{1F1EC}\u{1F1E7}",
+  Australia: "\u{1F1E6}\u{1F1FA}",
+  France: "\u{1F1EB}\u{1F1F7}",
+  Germany: "\u{1F1E9}\u{1F1EA}",
+  Spain: "\u{1F1EA}\u{1F1F8}",
+  Denmark: "\u{1F1E9}\u{1F1F0}",
+  Mexico: "\u{1F1F2}\u{1F1FD}",
+  Chile: "\u{1F1E8}\u{1F1F1}",
+  Switzerland: "\u{1F1E8}\u{1F1ED}",
+  "New Zealand": "\u{1F1F3}\u{1F1FF}",
+  "South Africa": "\u{1F1FF}\u{1F1E6}",
+  Bahrain: "\u{1F1E7}\u{1F1ED}",
+  Wales: "\u{1F3F4}\u{E0067}\u{E0062}\u{E0077}\u{E006C}\u{E0073}\u{E007F}",
+};
+
+export function getCountryFlag(location: string): string {
+  for (const [country, flag] of Object.entries(COUNTRY_FLAGS)) {
+    if (location.endsWith(country) || location === country) {
+      return flag;
+    }
+  }
+  // Handle "Wales, UK" specifically
+  if (location.includes("Wales")) return COUNTRY_FLAGS.Wales;
+  return "";
+}

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -63,4 +63,5 @@ export interface RaceInfo {
   name: string;
   date: string;
   location: string;
+  finishers: number;
 }


### PR DESCRIPTION
## Summary
- Add distance badges (blue "70.3" / orange "140.6") and colored left border accent to each race card
- Display country flag emojis next to race locations (covers all 14 countries in the dataset)
- Show finisher counts from `races.json` directly via new `finishers` field on `RaceInfo`, eliminating CSV parsing on the races page
- Format dates as human-readable (e.g., "Sep 20, 2025") instead of raw ISO strings
- Add hover effects: subtle lift, shadow, background shift, and name color transition

## Test plan
- [ ] `cd app && npm run build` passes with no type errors
- [ ] Visually verify `/races` page shows distance badges, flags, finisher counts
- [ ] Confirm 70.3 races show blue badge/accent and full IM races show orange
- [ ] Confirm flags display correctly for all countries

🤖 Generated with [Claude Code](https://claude.com/claude-code)