### PR TITLE
Add deduplicated athlete search and profile page

### DIFF
--- a/app/src/app/api/search/route.ts
+++ b/app/src/app/api/search/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getGlobalSearchIndex } from "@/lib/data";
-import { GlobalSearchEntry } from "@/lib/types";
+import { getDeduplicatedAthleteIndex } from "@/lib/data";
+import { AthleteSearchEntry } from "@/lib/types";
 
-let cachedIndex: (GlobalSearchEntry & { fullNameLower: string })[] | null = null;
+let cachedIndex: (AthleteSearchEntry & { fullNameLower: string })[] | null = null;
 
 function getIndex() {
   if (!cachedIndex) {
-    cachedIndex = getGlobalSearchIndex().map((entry) => ({
+    cachedIndex = getDeduplicatedAthleteIndex().map((entry) => ({
       ...entry,
       fullNameLower: entry.fullName.toLowerCase(),
     }));
@@ -21,17 +21,16 @@ export async function GET(request: NextRequest) {
   }
 
   const index = getIndex();
-  const results: GlobalSearchEntry[] = [];
+  const results: AthleteSearchEntry[] = [];
 
   for (const entry of index) {
     if (entry.fullNameLower.includes(q)) {
       results.push({
-        id: entry.id,
+        slug: entry.slug,
         fullName: entry.fullName,
-        ageGroup: entry.ageGroup,
         country: entry.country,
-        raceSlug: entry.raceSlug,
-        raceName: entry.raceName,
+        countryISO: entry.countryISO,
+        raceCount: entry.raceCount,
       });
       if (results.length >= 10) break;
     }

--- a/app/src/app/athlete/[slug]/page.tsx
+++ b/app/src/app/athlete/[slug]/page.tsx
@@ -1,0 +1,54 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { getAthleteProfile } from "@/lib/data";
+
+export async function generateStaticParams() {
+  return [];
+}
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function AthletePage({ params }: PageProps) {
+  const { slug } = await params;
+  const profile = getAthleteProfile(slug);
+  if (!profile) notFound();
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-8">
+      <Link href="/" className="text-blue-400 hover:underline text-sm mb-6 inline-block">
+        &larr; Back to search
+      </Link>
+
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold text-white">{profile.fullName}</h1>
+        <p className="text-gray-400 mt-1">
+          {profile.country} &middot; {profile.races.length} {profile.races.length === 1 ? "race" : "races"}
+        </p>
+      </header>
+
+      <div className="space-y-4">
+        {profile.races.map((race) => (
+          <Link
+            key={`${race.raceSlug}-${race.resultId}`}
+            href={`/race/${race.raceSlug}/result/${race.resultId}`}
+            className="block bg-gray-900 border border-gray-800 rounded-lg px-5 py-4 hover:border-gray-600 transition-colors"
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="font-medium text-white">{race.raceName}</div>
+                <div className="text-sm text-gray-400 mt-1">
+                  {race.raceDate} &middot; {race.ageGroup}
+                </div>
+              </div>
+              <div className="text-right">
+                <div className="text-lg font-mono text-white">{race.finishTime}</div>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/src/components/GlobalSearchBar.tsx
+++ b/app/src/components/GlobalSearchBar.tsx
@@ -2,11 +2,11 @@
 
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { GlobalSearchEntry } from "@/lib/types";
+import { AthleteSearchEntry } from "@/lib/types";
 
 export default function GlobalSearchBar() {
   const [query, setQuery] = useState("");
-  const [matches, setMatches] = useState<GlobalSearchEntry[]>([]);
+  const [matches, setMatches] = useState<AthleteSearchEntry[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const router = useRouter();
@@ -45,7 +45,7 @@ export default function GlobalSearchBar() {
         const res = await fetch(`/api/search?q=${encodeURIComponent(value)}`, {
           signal: controller.signal,
         });
-        const data: GlobalSearchEntry[] = await res.json();
+        const data: AthleteSearchEntry[] = await res.json();
         setMatches(data);
         setIsOpen(data.length > 0);
       } catch {
@@ -54,10 +54,10 @@ export default function GlobalSearchBar() {
     }, 300);
   }
 
-  function handleSelect(entry: GlobalSearchEntry) {
+  function handleSelect(entry: AthleteSearchEntry) {
     setQuery(entry.fullName);
     setIsOpen(false);
-    router.push(`/race/${entry.raceSlug}/result/${entry.id}`);
+    router.push(`/athlete/${entry.slug}`);
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -91,7 +91,7 @@ export default function GlobalSearchBar() {
         <ul className="absolute z-50 w-full mt-1 bg-gray-900 border border-gray-700 rounded-lg shadow-lg max-h-80 overflow-y-auto">
           {matches.map((entry, i) => (
             <li
-              key={`${entry.raceSlug}-${entry.id}`}
+              key={entry.slug}
               onClick={() => handleSelect(entry)}
               className={`px-4 py-3 cursor-pointer border-b border-gray-800 last:border-b-0 ${
                 i === selectedIndex ? "bg-gray-800" : "hover:bg-gray-800"
@@ -99,7 +99,7 @@ export default function GlobalSearchBar() {
             >
               <div className="font-medium text-white">{entry.fullName}</div>
               <div className="text-sm text-gray-400">
-                {entry.raceName} &middot; {entry.ageGroup} &middot; {entry.country}
+                {entry.country} &middot; {entry.raceCount} {entry.raceCount === 1 ? "race" : "races"}
               </div>
             </li>
           ))}

--- a/app/src/lib/data.ts
+++ b/app/src/lib/data.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { AthleteResult, GlobalSearchEntry, HistogramBin, HistogramData, RaceInfo, SearchEntry } from "./types";
+import { AthleteResult, AthleteProfile, AthleteRaceEntry, AthleteSearchEntry, HistogramBin, HistogramData, RaceInfo, SearchEntry } from "./types";
 
 interface RaceManifestEntry {
   slug: string;
@@ -126,21 +126,87 @@ export function getSearchIndex(raceSlug: string): SearchEntry[] {
   }));
 }
 
-export function getGlobalSearchIndex(): GlobalSearchEntry[] {
-  const entries: GlobalSearchEntry[] = [];
+function slugifyAthlete(fullName: string, countryISO: string, gender: string): string {
+  const base = fullName
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  const country = countryISO.toLowerCase();
+  const g = gender.toLowerCase().charAt(0);
+  return `${base}--${country}-${g}`;
+}
+
+let athleteIndexCache: AthleteSearchEntry[] | null = null;
+
+interface AthleteAccumulator {
+  fullName: string;
+  country: string;
+  countryISO: string;
+  raceCount: number;
+}
+
+export function getDeduplicatedAthleteIndex(): AthleteSearchEntry[] {
+  if (athleteIndexCache) return athleteIndexCache;
+
+  const map = new Map<string, AthleteAccumulator>();
   for (const race of getRacesInternal()) {
     for (const r of getAllResults(race.slug)) {
-      entries.push({
-        id: r.id,
-        fullName: r.fullName,
-        ageGroup: r.ageGroup,
-        country: r.country,
-        raceSlug: race.slug,
-        raceName: race.name,
-      });
+      const slug = slugifyAthlete(r.fullName, r.countryISO, r.gender);
+      const existing = map.get(slug);
+      if (existing) {
+        existing.raceCount++;
+      } else {
+        map.set(slug, {
+          fullName: r.fullName,
+          country: r.country,
+          countryISO: r.countryISO,
+          raceCount: 1,
+        });
+      }
     }
   }
-  return entries;
+
+  athleteIndexCache = Array.from(map.entries()).map(([slug, a]) => ({
+    slug,
+    fullName: a.fullName,
+    country: a.country,
+    countryISO: a.countryISO,
+    raceCount: a.raceCount,
+  }));
+  return athleteIndexCache;
+}
+
+export function getAthleteProfile(slug: string): AthleteProfile | null {
+  const races: AthleteRaceEntry[] = [];
+  let fullName = "";
+  let country = "";
+  let countryISO = "";
+
+  for (const race of getRacesInternal()) {
+    for (const r of getAllResults(race.slug)) {
+      if (slugifyAthlete(r.fullName, r.countryISO, r.gender) === slug) {
+        fullName = r.fullName;
+        country = r.country;
+        countryISO = r.countryISO;
+        races.push({
+          raceSlug: race.slug,
+          raceName: race.name,
+          raceDate: race.date,
+          resultId: r.id,
+          finishTime: r.finishTime,
+          ageGroup: r.ageGroup,
+        });
+      }
+    }
+  }
+
+  if (races.length === 0) return null;
+
+  races.sort((a, b) => b.raceDate.localeCompare(a.raceDate));
+
+  return { slug, fullName, country, countryISO, races };
 }
 
 export function getGlobalStats(): { raceCount: number; totalResults: number } {

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -49,13 +49,29 @@ export interface SearchEntry {
   country: string;
 }
 
-export interface GlobalSearchEntry {
-  id: number;
-  fullName: string;
-  ageGroup: string;
-  country: string;
+export interface AthleteRaceEntry {
   raceSlug: string;
   raceName: string;
+  raceDate: string;
+  resultId: number;
+  finishTime: string;
+  ageGroup: string;
+}
+
+export interface AthleteSearchEntry {
+  slug: string;
+  fullName: string;
+  country: string;
+  countryISO: string;
+  raceCount: number;
+}
+
+export interface AthleteProfile {
+  slug: string;
+  fullName: string;
+  country: string;
+  countryISO: string;
+  races: AthleteRaceEntry[];
 }
 
 export interface RaceInfo {


### PR DESCRIPTION
## Summary
- **Deduplicated search index**: Groups race results by athlete identity (name + country + gender), reducing ~949K entries to ~462K unique athletes. Search results now show race count instead of individual race info.
- **Athlete profile page**: New `/athlete/[slug]` page listing all of an athlete's race results (sorted most recent first), each linking to the existing result detail page.
- **Slug format**: `name--country-gender` (e.g. `john-smith--us-m`) for URL-safe, collision-resistant athlete identifiers.

## Test plan
- [ ] Search for an athlete name — results should be deduplicated with race count shown
- [ ] Click a search result — navigates to athlete profile page
- [ ] Verify athlete profile shows all races sorted by date (most recent first)
- [ ] Click a race from the profile — navigates to existing result detail page
- [ ] `npm run build` passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)