### PR TITLE
Add country flags, median comparisons, and discipline splits

### DIFF
--- a/app/src/app/athlete/[slug]/page.tsx
+++ b/app/src/app/athlete/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getAthleteProfile } from "@/lib/data";
+import { getCountryFlagISO } from "@/lib/flags";
 
 export async function generateStaticParams() {
   return [];
@@ -15,6 +16,8 @@ export default async function AthletePage({ params }: PageProps) {
   const profile = getAthleteProfile(slug);
   if (!profile) notFound();
 
+  const flag = getCountryFlagISO(profile.countryISO);
+
   return (
     <main className="max-w-4xl mx-auto px-4 py-8">
       <Link href="/" className="text-blue-400 hover:underline text-sm mb-6 inline-block">
@@ -22,7 +25,10 @@ export default async function AthletePage({ params }: PageProps) {
       </Link>
 
       <header className="mb-8">
-        <h1 className="text-3xl font-bold text-white">{profile.fullName}</h1>
+        <h1 className="text-3xl font-bold text-white">
+          {flag && <span className="mr-2">{flag}</span>}
+          {profile.fullName}
+        </h1>
         <p className="text-gray-400 mt-1">
           {profile.country} &middot; {profile.races.length} {profile.races.length === 1 ? "race" : "races"}
         </p>
@@ -44,6 +50,13 @@ export default async function AthletePage({ params }: PageProps) {
               </div>
               <div className="text-right">
                 <div className="text-lg font-mono text-white">{race.finishTime}</div>
+                <div className="text-xs font-mono text-gray-500 mt-1">
+                  <span className="text-blue-400">{race.swimTime}</span>
+                  {" / "}
+                  <span className="text-green-400">{race.bikeTime}</span>
+                  {" / "}
+                  <span className="text-amber-400">{race.runTime}</span>
+                </div>
               </div>
             </div>
           </Link>

--- a/app/src/app/race/[slug]/result/[id]/page.tsx
+++ b/app/src/app/race/[slug]/result/[id]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { getRaceBySlug, getAthleteById, getDisciplineHistogram, getGenderCount, getAgeGroupCount, getAllResults, type Discipline } from "@/lib/data";
 import ResultCard from "@/components/ResultCard";
 import DisciplineSections from "@/components/DisciplineSections";
+import { getCountryFlagISO } from "@/lib/flags";
 
 // Don't pre-render all 75K+ athlete pages at build time — generate on demand.
 // Next.js will render on first request and cache for subsequent visits.
@@ -54,6 +55,31 @@ export default async function ResultPage({ params }: PageProps) {
   const genderPct = Math.max(1, Math.round((athlete.genderRank / genderTotal) * 100));
   const ageGroupPct = Math.max(1, Math.round((athlete.ageGroupRank / ageGroupTotal) * 100));
 
+  const flag = getCountryFlagISO(athlete.countryISO);
+  const location = [athlete.city, athlete.state, athlete.country].filter(Boolean).join(", ");
+
+  const DISCIPLINE_COLORS: Record<string, string> = {
+    Swim: "#3b82f6",
+    Bike: "#22c55e",
+    Run: "#f59e0b",
+    Total: "#ef4444",
+  };
+
+  const medianComparisons = histograms.map((d) => {
+    const athleteSec = d.overall.athleteSeconds;
+    const medianSec = d.overall.medianSeconds;
+    const deltaSec = athleteSec - medianSec;
+    const faster = deltaSec < 0;
+    return {
+      label: d.label,
+      time: d.time,
+      medianSeconds: medianSec,
+      deltaSec,
+      faster,
+      color: DISCIPLINE_COLORS[d.label] || "#6b7280",
+    };
+  });
+
   return (
     <main className="max-w-4xl mx-auto px-4 py-8">
       <Link href={`/race/${slug}`} className="text-blue-400 hover:underline text-sm mb-6 inline-block">
@@ -61,10 +87,12 @@ export default async function ResultPage({ params }: PageProps) {
       </Link>
 
       <header className="mb-8">
-        <h1 className="text-3xl font-bold text-white">{athlete.fullName}</h1>
+        <h1 className="text-3xl font-bold text-white">
+          {flag && <span className="mr-2">{flag}</span>}
+          {athlete.fullName}
+        </h1>
         <p className="text-gray-400 mt-1">
-          {race.name} &middot; Bib #{athlete.bib} &middot; {athlete.ageGroup} &middot;{" "}
-          {[athlete.city, athlete.state, athlete.country].filter(Boolean).join(", ")}
+          {race.name} &middot; Bib #{athlete.bib} &middot; {athlete.ageGroup} &middot; {location}
         </p>
       </header>
 
@@ -88,6 +116,33 @@ export default async function ResultPage({ params }: PageProps) {
           value={`Top ${ageGroupPct}%`}
           subtext={`${athlete.ageGroupRank} of ${ageGroupTotal} · ${athlete.ageGroup}`}
         />
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        {medianComparisons.map((d) => {
+          const absDelta = Math.abs(d.deltaSec);
+          const h = Math.floor(absDelta / 3600);
+          const m = Math.floor((absDelta % 3600) / 60);
+          const s = Math.round(absDelta % 60);
+          const deltaStr = h > 0
+            ? `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`
+            : `${m}:${String(s).padStart(2, "0")}`;
+
+          return (
+            <div
+              key={d.label}
+              className="bg-gray-900 rounded-lg border border-gray-700 p-4 text-center"
+            >
+              <div className="text-sm font-medium mb-1" style={{ color: d.color }}>
+                {d.label}
+              </div>
+              <div className="text-lg font-mono font-bold text-white">{d.time}</div>
+              <div className={`text-sm font-mono mt-1 ${d.faster ? "text-green-400" : "text-red-400"}`}>
+                {d.faster ? "-" : "+"}{deltaStr} vs median
+              </div>
+            </div>
+          );
+        })}
       </div>
 
       <DisciplineSections

--- a/app/src/components/Histogram.tsx
+++ b/app/src/components/Histogram.tsx
@@ -59,6 +59,15 @@ export default function Histogram({ data, color, label }: Props) {
             strokeWidth={2}
             strokeDasharray="4 4"
           />
+          {data.medianSeconds > 0 && (
+            <ReferenceLine
+              x={data.bins.find((b) => data.medianSeconds >= b.rangeStart && data.medianSeconds < b.rangeEnd)?.label}
+              stroke="#9ca3af"
+              strokeWidth={1.5}
+              strokeDasharray="6 3"
+              label={{ value: "Median", position: "top", fill: "#9ca3af", fontSize: 11 }}
+            />
+          )}
           <Bar dataKey="count" radius={[2, 2, 0, 0]}>
             {data.bins.map((bin, i) => (
               <Cell

--- a/app/src/lib/data.ts
+++ b/app/src/lib/data.ts
@@ -197,6 +197,9 @@ export function getAthleteProfile(slug: string): AthleteProfile | null {
           resultId: r.id,
           finishTime: r.finishTime,
           ageGroup: r.ageGroup,
+          swimTime: r.swimTime,
+          bikeTime: r.bikeTime,
+          runTime: r.runTime,
         });
       }
     }
@@ -226,6 +229,13 @@ function formatSecondsShort(seconds: number): string {
   return `${m}m`;
 }
 
+function computeMedian(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
 export function computeHistogram(
   allSeconds: number[],
   athleteSeconds: number,
@@ -233,7 +243,7 @@ export function computeHistogram(
 ): HistogramData {
   const valid = allSeconds.filter((s) => s > 0);
   if (valid.length === 0) {
-    return { bins: [], athleteSeconds, athletePercentile: 0 };
+    return { bins: [], athleteSeconds, athletePercentile: 0, medianSeconds: 0 };
   }
 
   const min = Math.floor(Math.min(...valid) / binSize) * binSize;
@@ -257,7 +267,9 @@ export function computeHistogram(
   const slowerCount = valid.filter((s) => s > athleteSeconds).length;
   const athletePercentile = Math.round((slowerCount / valid.length) * 100);
 
-  return { bins, athleteSeconds, athletePercentile };
+  const medianSeconds = computeMedian(valid);
+
+  return { bins, athleteSeconds, athletePercentile, medianSeconds };
 }
 
 export type Discipline = "swim" | "bike" | "run" | "finish" | "t1" | "t2";

--- a/app/src/lib/flags.ts
+++ b/app/src/lib/flags.ts
@@ -26,3 +26,12 @@ export function getCountryFlag(location: string): string {
   if (location.includes("Wales")) return COUNTRY_FLAGS.Wales;
   return "";
 }
+
+export function getCountryFlagISO(iso: string): string {
+  if (!iso || iso.length !== 2) return "";
+  const upper = iso.toUpperCase();
+  return String.fromCodePoint(
+    0x1f1e6 + upper.charCodeAt(0) - 65,
+    0x1f1e6 + upper.charCodeAt(1) - 65,
+  );
+}

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -40,6 +40,7 @@ export interface HistogramData {
   bins: HistogramBin[];
   athleteSeconds: number;
   athletePercentile: number;
+  medianSeconds: number;
 }
 
 export interface SearchEntry {
@@ -56,6 +57,9 @@ export interface AthleteRaceEntry {
   resultId: number;
   finishTime: string;
   ageGroup: string;
+  swimTime: string;
+  bikeTime: string;
+  runTime: string;
 }
 
 export interface AthleteSearchEntry {


### PR DESCRIPTION
## Summary
- Add ISO-based country flag emojis next to athlete names on profile and result pages
- Add discipline comparison cards (Swim, Bike, Run, Total) showing athlete time vs. median with green/red +/- delta indicators
- Add median reference line on all discipline histograms
- Show color-coded swim/bike/run split times on athlete profile race cards

Closes #8

## Test plan
- [ ] Visit `/race/<slug>/result/<id>` — verify flag emoji appears next to name, median comparison cards show below placement cards, histograms show gray dashed median line
- [ ] Visit `/athlete/<slug>` — verify flag emoji appears next to name, each race card shows color-coded swim/bike/run splits
- [ ] Verify `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)