### PR TITLE
docs: add conventional commits instruction to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,3 +81,7 @@ node scripts/scrape-all.js [--slug=<slug>] [--year=2025] [--dry-run] [--save-raw
 # Build search index (runs automatically during npm run build)
 node scripts/build-search-index.js
 ```
+
+## Conventions
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages and PR titles (e.g. `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`)


### PR DESCRIPTION
Add a new Conventions section to CLAUDE.md to instruct Claude Code to use Conventional Commits for commit messages and PR titles.

This ensures consistent commit history and PR naming going forward, making it easier to parse commit messages and generate changelogs automatically.