### PR TITLE
docs: expand README with local development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,19 @@ ironman.com results page
   → Next.js app reads races.json + CSVs at build time
 ```
 
-## Development
+## Local Development
+
+Prerequisites: [Node.js](https://nodejs.org/) 18+
 
 ```bash
 cd app
 npm install
 npm run dev
 ```
+
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Start Next.js development server |
+| `npm run build` | Build for production (also generates search index) |
+| `npm run start` | Start production server |
+| `npm run lint` | Run ESLint |


### PR DESCRIPTION
## Summary

- Renamed "Development" section to "Local Development" for clarity
- Added Node.js 18+ prerequisite with link to nodejs.org
- Added a table documenting all available npm commands: dev, build, start, and lint
- Helps new contributors get started quickly with clear setup instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)