### PR TITLE
fix: remove browse all races link from home page

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import GlobalSearchBar from "@/components/GlobalSearchBar";
 
 export default function Home() {
@@ -23,16 +22,9 @@ export default function Home() {
             See where you stand in swim, bike, run, and overall.
           </p>
 
-          <div className="w-full max-w-lg mb-4">
+          <div className="w-full max-w-lg">
             <GlobalSearchBar />
           </div>
-
-          <Link
-            href="/races"
-            className="text-sm text-gray-500 hover:text-gray-300 transition-colors"
-          >
-            or browse all races &rarr;
-          </Link>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
Removed the "or browse all races →" link from the home page hero section. The link was redundant since users can navigate to /races through the header navigation or by searching for athletes.

## Changes
- Removed unused `Link` import
- Deleted the link element below the global search bar
- Adjusted spacing on the search bar wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)