### PR TITLE
chore: suppress npm audit warnings on install

### DIFF
--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,0 +1,1 @@
+audit=false


### PR DESCRIPTION
## Summary
- Add `app/.npmrc` with `audit=false` to suppress the 15 vulnerability warnings that appear during `npm install`
- All 15 vulnerabilities are in the eslint devDependency toolchain (transitive `minimatch` and `ajv` deps), not production code
- Manual `npm audit` still works on demand

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)