### PR TITLE
Standardize discipline colors across app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Data is collected from https://www.ironman.com/races/im703-new-york/results. Ins
 
 - `app/src/lib/data.ts` — Server-side data access (reads CSVs, computes histograms, athlete deduplication & profiles)
 - `app/src/lib/types.ts` — TypeScript interfaces (`AthleteSearchEntry`, `AthleteProfile`, `AthleteRaceEntry`, etc.)
+- `app/src/lib/colors.ts` — Canonical discipline color constants (swim, bike, run, overall, T1, T2)
 - `app/src/lib/flags.ts` — Country ISO to flag emoji mapping
 - `app/src/components/GlobalSearchBar.tsx` — Cross-race athlete search with debounce, caching, and keyboard nav
 - `app/src/components/SearchBar.tsx` — Single-race in-page athlete search
@@ -81,6 +82,19 @@ node scripts/scrape-all.js [--slug=<slug>] [--year=2025] [--dry-run] [--save-raw
 # Build search index (runs automatically during npm run build)
 node scripts/build-search-index.js
 ```
+
+## Design: Discipline Colors
+
+Canonical colors for triathlon disciplines. Defined in `app/src/lib/colors.ts` — always import from there, never hardcode.
+
+| Discipline | Hex       | Tailwind    |
+|------------|-----------|-------------|
+| Swim       | `#3b82f6` | `blue-400`  |
+| Bike       | `#ef4444` | `red-400`   |
+| Run        | `#f59e0b` | `amber-400` |
+| Overall    | `#9ca3af` | `gray-400`  |
+| T1         | `#8b5cf6` | `purple-400`|
+| T2         | `#ec4899` | `pink-400`  |
 
 ## Conventions
 

--- a/app/src/app/athlete/[slug]/page.tsx
+++ b/app/src/app/athlete/[slug]/page.tsx
@@ -53,7 +53,7 @@ export default async function AthletePage({ params }: PageProps) {
                 <div className="text-xs font-mono text-gray-500 mt-1">
                   <span className="text-blue-400">{race.swimTime}</span>
                   {" / "}
-                  <span className="text-green-400">{race.bikeTime}</span>
+                  <span className="text-red-400">{race.bikeTime}</span>
                   {" / "}
                   <span className="text-amber-400">{race.runTime}</span>
                 </div>

--- a/app/src/app/race/[slug]/result/[id]/page.tsx
+++ b/app/src/app/race/[slug]/result/[id]/page.tsx
@@ -4,6 +4,7 @@ import { getRaceBySlug, getAthleteById, getDisciplineHistogram, getGenderCount, 
 import ResultCard from "@/components/ResultCard";
 import DisciplineSections from "@/components/DisciplineSections";
 import { getCountryFlagISO } from "@/lib/flags";
+import { DISCIPLINE_COLORS, DEFAULT_DISCIPLINE_COLOR } from "@/lib/colors";
 
 // Don't pre-render all 75K+ athlete pages at build time — generate on demand.
 // Next.js will render on first request and cache for subsequent visits.
@@ -58,12 +59,6 @@ export default async function ResultPage({ params }: PageProps) {
   const flag = getCountryFlagISO(athlete.countryISO);
   const location = [athlete.city, athlete.state, athlete.country].filter(Boolean).join(", ");
 
-  const DISCIPLINE_COLORS: Record<string, string> = {
-    Swim: "#3b82f6",
-    Bike: "#ef4444",
-    Run: "#f59e0b",
-    Total: "#22c55e",
-  };
 
   return (
     <main className="max-w-4xl mx-auto px-4 py-8">
@@ -106,7 +101,7 @@ export default async function ResultPage({ params }: PageProps) {
             key={d.key}
             className="bg-gray-900 rounded-lg border border-gray-700 p-4 text-center"
           >
-            <div className="text-sm font-medium mb-1" style={{ color: DISCIPLINE_COLORS[d.label] || "#6b7280" }}>
+            <div className="text-sm font-medium mb-1" style={{ color: DISCIPLINE_COLORS[d.label] || DEFAULT_DISCIPLINE_COLOR }}>
               {d.label}
             </div>
             <div className="text-lg font-mono font-bold text-white">{d.time}</div>

--- a/app/src/components/DisciplineSection.tsx
+++ b/app/src/components/DisciplineSection.tsx
@@ -1,14 +1,6 @@
 import Histogram from "./Histogram";
 import { HistogramData } from "@/lib/types";
-
-const COLORS: Record<string, string> = {
-  Swim: "#3b82f6",
-  Bike: "#ef4444",
-  Run: "#f59e0b",
-  Total: "#22c55e",
-  "T1 (Swim → Bike)": "#8b5cf6",
-  "T2 (Bike → Run)": "#ec4899",
-};
+import { DISCIPLINE_COLORS, DEFAULT_DISCIPLINE_COLOR } from "@/lib/colors";
 
 interface Props {
   discipline: string;
@@ -27,7 +19,7 @@ export default function DisciplineSection({
   ageGroup,
   scope,
 }: Props) {
-  const color = COLORS[discipline] || "#6b7280";
+  const color = DISCIPLINE_COLORS[discipline] || DEFAULT_DISCIPLINE_COLOR;
   const data = scope === "overall" ? overallData : ageGroupData;
   const label = scope === "overall" ? "Overall Field" : `Age Group: ${ageGroup}`;
 

--- a/app/src/lib/colors.ts
+++ b/app/src/lib/colors.ts
@@ -1,0 +1,11 @@
+/** Canonical discipline colors used across charts and UI. */
+export const DISCIPLINE_COLORS: Record<string, string> = {
+  Swim: "#3b82f6",
+  Bike: "#ef4444",
+  Run: "#f59e0b",
+  Total: "#9ca3af",
+  "T1 (Swim → Bike)": "#8b5cf6",
+  "T2 (Bike → Run)": "#ec4899",
+};
+
+export const DEFAULT_DISCIPLINE_COLOR = "#6b7280";


### PR DESCRIPTION
## Summary
- Created `app/src/lib/colors.ts` as the canonical source for discipline colors (swim, bike, run, overall, T1, T2)
- Updated all color consumers to import from the shared module instead of using inline constants
- Fixed athlete profile page showing bike in green — now correctly displays in red
- Changed overall/total color from green to gray for better visual distinction

## Test plan
- Build completes without errors
- Athlete profile shows blue/red/amber for swim/bike/run times
- Result page histograms display blue/red/amber/gray for swim/bike/run/total