### PR TITLE
feat: add stats page with aggregate race data

### DIFF
--- a/app/src/app/stats/page.tsx
+++ b/app/src/app/stats/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { getStatsPageData } from "@/lib/data";
+
+export const metadata = {
+  title: "Stats | TriTimes",
+  description:
+    "Aggregate statistics across all IRONMAN and IRONMAN 70.3 races tracked by TriTimes.",
+};
+
+export default function StatsPage() {
+  const stats = getStatsPageData();
+
+  return (
+    <main className="max-w-5xl mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold text-white mb-8">Stats</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">
+          <p className="text-sm text-gray-400">Race Results</p>
+          <p className="text-3xl font-bold text-white mt-1">
+            {stats.totalResults.toLocaleString()}
+          </p>
+        </div>
+        <div className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">
+          <p className="text-sm text-gray-400">Unique Athletes</p>
+          <p className="text-3xl font-bold text-white mt-1">
+            {stats.uniqueAthletes.toLocaleString()}
+          </p>
+        </div>
+        <div className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">
+          <p className="text-sm text-gray-400">Races</p>
+          <p className="text-3xl font-bold text-white mt-1">
+            {stats.raceCount.toLocaleString()}
+          </p>
+        </div>
+        <div className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">
+          <p className="text-sm text-gray-400">Earliest Race</p>
+          <Link
+            href={`/race/${stats.earliestRace.slug}`}
+            className="text-lg font-semibold text-white hover:text-blue-400 transition-colors mt-1 block"
+          >
+            {stats.earliestRace.name}
+          </Link>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {stats.earliestRace.date}
+          </p>
+        </div>
+        <div className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">
+          <p className="text-sm text-gray-400">Most Recent Race</p>
+          <Link
+            href={`/race/${stats.mostRecentRace.slug}`}
+            className="text-lg font-semibold text-white hover:text-blue-400 transition-colors mt-1 block"
+          >
+            {stats.mostRecentRace.name}
+          </Link>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {stats.mostRecentRace.date}
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -14,6 +14,9 @@ export default function Header() {
           <Link href="/courses" className="text-sm text-gray-400 hover:text-white transition-colors">
             Courses
           </Link>
+          <Link href="/stats" className="text-sm text-gray-400 hover:text-white transition-colors">
+            Stats
+          </Link>
         </nav>
       </div>
     </header>

--- a/app/src/lib/data.ts
+++ b/app/src/lib/data.ts
@@ -251,6 +251,29 @@ export function getGlobalStats(): { raceCount: number; totalResults: number } {
   };
 }
 
+export interface StatsPageData {
+  raceCount: number;
+  totalResults: number;
+  uniqueAthletes: number;
+  earliestRace: { slug: string; name: string; date: string };
+  mostRecentRace: { slug: string; name: string; date: string };
+}
+
+export function getStatsPageData(): StatsPageData {
+  const races = getRacesInternal();
+  const sorted = [...races].sort((a, b) => a.date.localeCompare(b.date));
+  const earliest = sorted[0];
+  const mostRecent = sorted[sorted.length - 1];
+
+  return {
+    raceCount: races.length,
+    totalResults: races.reduce((sum, r) => sum + r.finishers, 0),
+    uniqueAthletes: getDeduplicatedAthleteIndex().length,
+    earliestRace: { slug: earliest.slug, name: earliest.name, date: earliest.date },
+    mostRecentRace: { slug: mostRecent.slug, name: mostRecent.name, date: mostRecent.date },
+  };
+}
+
 function formatSecondsShort(seconds: number): string {
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);


### PR DESCRIPTION
## Summary

Add `/stats` page displaying aggregate statistics across all races: total race results, unique athletes, race count, earliest race, and most recent race. New `getStatsPageData()` function computes these metrics from existing data access functions. Stats link added to main navigation header.

## Changes

- New `/stats` page with responsive stat cards
- `getStatsPageData()` function in data.ts for computing aggregate stats
- Stats navigation link in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)