### PR TITLE
Split top finishers leaderboard by gender

### DIFF
--- a/app/src/app/race/[slug]/page.tsx
+++ b/app/src/app/race/[slug]/page.tsx
@@ -166,46 +166,48 @@ export default async function RacePage({ params }: PageProps) {
         </div>
       </section>
 
-      {/* Leaderboard */}
+      {/* Leaderboards by gender */}
       <section className="mb-10">
         <h2 className="text-xl font-bold text-white mb-4">Top Finishers</h2>
-        <div className="bg-gray-900 rounded-lg border border-gray-700 overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-gray-700 text-gray-400">
-                <th className="text-left px-4 py-3 font-medium w-10">#</th>
-                <th className="text-left px-4 py-3 font-medium">Name</th>
-                <th className="text-left px-4 py-3 font-medium hidden md:table-cell">AG</th>
-                <th className="text-right px-4 py-3 font-medium">Finish</th>
-                <th className="text-right px-4 py-3 font-medium hidden md:table-cell">Swim</th>
-                <th className="text-right px-4 py-3 font-medium hidden md:table-cell">Bike</th>
-                <th className="text-right px-4 py-3 font-medium hidden md:table-cell">Run</th>
-              </tr>
-            </thead>
-            <tbody>
-              {stats.leaderboard.map((entry) => {
-                const flag = getCountryFlagISO(entry.countryISO);
-                return (
-                  <tr key={entry.id} className="border-b border-gray-800 last:border-b-0 hover:bg-gray-800/50">
-                    <td className="px-4 py-3 text-gray-400">{entry.rank}</td>
-                    <td className="px-4 py-3">
-                      <Link
-                        href={`/race/${slug}/result/${entry.id}`}
-                        className="text-white hover:text-blue-400 transition-colors"
-                      >
-                        {flag} {entry.fullName}
-                      </Link>
-                    </td>
-                    <td className="px-4 py-3 text-gray-400 hidden md:table-cell">{entry.ageGroup}</td>
-                    <td className="px-4 py-3 text-right font-mono font-bold text-white">{entry.finishTime}</td>
-                    <td className="px-4 py-3 text-right font-mono hidden md:table-cell" style={{ color: "#3b82f6" }}>{entry.swimTime}</td>
-                    <td className="px-4 py-3 text-right font-mono hidden md:table-cell" style={{ color: "#ef4444" }}>{entry.bikeTime}</td>
-                    <td className="px-4 py-3 text-right font-mono hidden md:table-cell" style={{ color: "#f59e0b" }}>{entry.runTime}</td>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {[
+            { title: "Top 10 Males", entries: stats.maleLeaderboard },
+            { title: "Top 10 Females", entries: stats.femaleLeaderboard },
+          ].map(({ title, entries }) => (
+            <div key={title} className="bg-gray-900 rounded-lg border border-gray-700 overflow-hidden">
+              <h3 className="text-sm font-medium text-gray-400 px-4 pt-4 pb-2">{title}</h3>
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-700 text-gray-400">
+                    <th className="text-left px-4 py-2 font-medium w-8">#</th>
+                    <th className="text-left px-4 py-2 font-medium">Name</th>
+                    <th className="text-left px-4 py-2 font-medium hidden lg:table-cell">AG</th>
+                    <th className="text-right px-4 py-2 font-medium">Finish</th>
                   </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                </thead>
+                <tbody>
+                  {entries.map((entry) => {
+                    const flag = getCountryFlagISO(entry.countryISO);
+                    return (
+                      <tr key={entry.id} className="border-b border-gray-800 last:border-b-0 hover:bg-gray-800/50">
+                        <td className="px-4 py-2 text-gray-400">{entry.rank}</td>
+                        <td className="px-4 py-2">
+                          <Link
+                            href={`/race/${slug}/result/${entry.id}`}
+                            className="text-white hover:text-blue-400 transition-colors"
+                          >
+                            {flag} {entry.fullName}
+                          </Link>
+                        </td>
+                        <td className="px-4 py-2 text-gray-400 hidden lg:table-cell">{entry.ageGroup}</td>
+                        <td className="px-4 py-2 text-right font-mono font-bold text-white">{entry.finishTime}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          ))}
         </div>
       </section>
     </main>

--- a/app/src/lib/data.ts
+++ b/app/src/lib/data.ts
@@ -427,23 +427,28 @@ export function getRaceStats(raceSlug: string): RaceStats {
     })
     .sort((a, b) => b.count - a.count);
 
-  // Top 10 leaderboard
-  const leaderboard: LeaderboardEntry[] = [...results]
-    .sort((a, b) => a.overallRank - b.overallRank)
-    .slice(0, 10)
-    .map((r) => ({
-      id: r.id,
-      rank: r.overallRank,
-      fullName: r.fullName,
-      country: r.country,
-      countryISO: r.countryISO,
-      ageGroup: r.ageGroup,
-      gender: r.gender,
-      finishTime: r.finishTime,
-      swimTime: r.swimTime,
-      bikeTime: r.bikeTime,
-      runTime: r.runTime,
-    }));
+  // Top 10 leaderboards by gender
+  function buildLeaderboard(gender: string): LeaderboardEntry[] {
+    return results
+      .filter((r) => r.gender === gender)
+      .sort((a, b) => a.genderRank - b.genderRank)
+      .slice(0, 10)
+      .map((r) => ({
+        id: r.id,
+        rank: r.genderRank,
+        fullName: r.fullName,
+        country: r.country,
+        countryISO: r.countryISO,
+        ageGroup: r.ageGroup,
+        gender: r.gender,
+        finishTime: r.finishTime,
+        swimTime: r.swimTime,
+        bikeTime: r.bikeTime,
+        runTime: r.runTime,
+      }));
+  }
+  const maleLeaderboard = buildLeaderboard("Male");
+  const femaleLeaderboard = buildLeaderboard("Female");
 
   // Histograms
   const histograms = {
@@ -458,7 +463,8 @@ export function getRaceStats(raceSlug: string): RaceStats {
     disciplines,
     genderBreakdown,
     ageGroupBreakdown,
-    leaderboard,
+    maleLeaderboard,
+    femaleLeaderboard,
     histograms,
   };
 }

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -135,7 +135,8 @@ export interface RaceStats {
   disciplines: DisciplineStats[];
   genderBreakdown: GenderBreakdown[];
   ageGroupBreakdown: AgeGroupBreakdown[];
-  leaderboard: LeaderboardEntry[];
+  maleLeaderboard: LeaderboardEntry[];
+  femaleLeaderboard: LeaderboardEntry[];
   histograms: {
     swim: RaceHistogramData;
     bike: RaceHistogramData;


### PR DESCRIPTION
## Summary
Display top 10 male and top 10 female finishers on race pages in separate leaderboards instead of a single overall top 10. Each leaderboard shows gender rank, name (linked to athlete result page), age group, and finish time. The tables are rendered side-by-side on medium+ screens and stack on mobile.

## Changes
- **types.ts**: Split `RaceStats.leaderboard` into `maleLeaderboard` and `femaleLeaderboard`
- **data.ts**: Updated `getRaceStats()` to build leaderboards filtered by gender and sorted by gender rank
- **race/[slug]/page.tsx**: Render two gender-specific leaderboards in a responsive 2-column grid

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)