### PR TITLE
fix: remove homepage scroll by adjusting main height

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -2,7 +2,7 @@ import GlobalSearchBar from "@/components/GlobalSearchBar";
 
 export default function Home() {
   return (
-    <main className="min-h-screen">
+    <main className="min-h-[calc(100dvh-3.5rem)]">
       {/* Hero section */}
       <section className="relative">
         {/* Background gradient */}


### PR DESCRIPTION
The homepage was scrollable because min-h-screen (100vh) was applied to the main element, while the sticky header (h-14/3.5rem) sat outside it, causing total height to exceed the viewport by the header height.

Changed to min-h-[calc(100dvh-3.5rem)] which subtracts the header height and uses dvh (dynamic viewport height) for proper mobile support where browser chrome shows and hides.