### PR TITLE
feat: add performance charts to athlete profile page

### DIFF
--- a/app/src/app/athlete/[slug]/page.tsx
+++ b/app/src/app/athlete/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getAthleteProfile } from "@/lib/data";
 import { getCountryFlagISO } from "@/lib/flags";
+import AthletePerformanceCharts from "@/components/AthletePerformanceCharts";
 
 export async function generateStaticParams() {
   return [];
@@ -43,9 +44,18 @@ export default async function AthletePage({ params }: PageProps) {
           >
             <div className="flex items-center justify-between">
               <div>
-                <div className="font-medium text-white">{race.raceName}</div>
+                <div className="flex items-center gap-2">
+                  <span className="font-medium text-white">{race.raceName}</span>
+                  <span className={`text-xs font-bold px-2 py-0.5 rounded-full ${
+                    race.distance === "70.3"
+                      ? "bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/30"
+                      : "bg-orange-500/20 text-orange-400 ring-1 ring-orange-500/30"
+                  }`}>
+                    {race.distance}
+                  </span>
+                </div>
                 <div className="text-sm text-gray-400 mt-1">
-                  {race.raceDate} &middot; {race.ageGroup}
+                  {race.raceDate} &middot; {race.ageGroup} &middot; Faster than {race.overallPercentile}%
                 </div>
               </div>
               <div className="text-right">
@@ -62,6 +72,8 @@ export default async function AthletePage({ params }: PageProps) {
           </Link>
         ))}
       </div>
+
+      <AthletePerformanceCharts races={[...profile.races].reverse()} />
     </main>
   );
 }

--- a/app/src/components/AthletePerformanceCharts.tsx
+++ b/app/src/components/AthletePerformanceCharts.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import type { AthleteRaceEntry } from "@/lib/types";
+import { formatTime } from "@/lib/format";
+
+const DISTANCE_COLORS: Record<string, string> = {
+  "70.3": "#3b82f6",
+  "140.6": "#f97316",
+};
+
+function formatDateShort(iso: string): string {
+  const date = new Date(iso + "T00:00:00");
+  return date.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}
+
+interface DataPoint {
+  dateLabel: string;
+  raceName: string;
+  time: number;
+  percentile: number;
+}
+
+interface Props {
+  races: AthleteRaceEntry[];
+}
+
+function TimeTooltip({ active, payload, color }: { active?: boolean; payload?: Array<{ payload: DataPoint }>; color: string }) {
+  if (!active || !payload?.length) return null;
+  const point = payload[0].payload;
+  return (
+    <div className="rounded-md px-3 py-2 text-[13px]" style={{ backgroundColor: "#1f2937", border: "1px solid #374151", color: "#ededed" }}>
+      <div className="font-semibold">{point.raceName}</div>
+      <div className="text-[11px] text-gray-400">{point.dateLabel}</div>
+      <div className="mt-1" style={{ color }}>
+        {formatTime(point.time)}
+      </div>
+    </div>
+  );
+}
+
+function PercentileTooltip({ active, payload, color }: { active?: boolean; payload?: Array<{ payload: DataPoint }>; color: string }) {
+  if (!active || !payload?.length) return null;
+  const point = payload[0].payload;
+  return (
+    <div className="rounded-md px-3 py-2 text-[13px]" style={{ backgroundColor: "#1f2937", border: "1px solid #374151", color: "#ededed" }}>
+      <div className="font-semibold">{point.raceName}</div>
+      <div className="text-[11px] text-gray-400">{point.dateLabel}</div>
+      <div className="mt-1" style={{ color }}>
+        Top {point.percentile}%
+      </div>
+    </div>
+  );
+}
+
+function DistanceSection({ label, races, color }: { label: string; races: AthleteRaceEntry[]; color: string }) {
+  if (races.length < 2) return null;
+
+  const dataPoints: DataPoint[] = races.map((r) => ({
+    dateLabel: formatDateShort(r.raceDate),
+    raceName: r.raceName,
+    time: r.finishSeconds,
+    percentile: 100 - r.overallPercentile,
+  }));
+
+  const step = Math.max(1, Math.floor(dataPoints.length / 8));
+
+  return (
+    <div>
+      <h3 className="text-lg font-semibold text-white mb-4">{label}</h3>
+      <div className="space-y-6">
+        <div>
+          <span className="text-sm font-medium text-gray-400">Finish Time</span>
+          <ResponsiveContainer width="100%" height={250}>
+            <LineChart data={dataPoints} margin={{ top: 10, right: 10, bottom: 5, left: 10 }}>
+              <XAxis
+                dataKey="dateLabel"
+                tick={{ fontSize: 11, fill: "#9ca3af" }}
+                interval={step - 1}
+              />
+              <YAxis
+                tickFormatter={(v: number) => formatTime(v)}
+                tick={{ fontSize: 11, fill: "#9ca3af" }}
+                width={55}
+              />
+              <Tooltip content={<TimeTooltip color={color} />} />
+              <Line
+                type="monotone"
+                dataKey="time"
+                stroke={color}
+                strokeWidth={2}
+                dot={{ r: 4, fill: color }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div>
+          <span className="text-sm font-medium text-gray-400">Finish Percentile</span>
+          <ResponsiveContainer width="100%" height={250}>
+            <LineChart data={dataPoints} margin={{ top: 10, right: 10, bottom: 5, left: 10 }}>
+              <XAxis
+                dataKey="dateLabel"
+                tick={{ fontSize: 11, fill: "#9ca3af" }}
+                interval={step - 1}
+              />
+              <YAxis
+                reversed
+                domain={[0, 100]}
+                tickFormatter={(v: number) => `${v}%`}
+                tick={{ fontSize: 11, fill: "#9ca3af" }}
+                width={40}
+              />
+              <Tooltip content={<PercentileTooltip color={color} />} />
+              <Line
+                type="monotone"
+                dataKey="percentile"
+                stroke={color}
+                strokeWidth={2}
+                dot={{ r: 4, fill: color }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function AthletePerformanceCharts({ races }: Props) {
+  const valid = races.filter((r) => r.finishSeconds > 0);
+  if (valid.length < 2) return null;
+
+  const races703 = valid.filter((r) => r.distance === "70.3");
+  const races1406 = valid.filter((r) => r.distance === "140.6");
+
+  const show703 = races703.length >= 2;
+  const show1406 = races1406.length >= 2;
+
+  if (!show703 && !show1406) return null;
+
+  return (
+    <section className="mt-8">
+      <h2 className="text-xl font-bold text-white mb-6">Performance Over Time</h2>
+      <div className="space-y-8">
+        {show703 && (
+          <DistanceSection
+            label="IRONMAN 70.3"
+            races={races703}
+            color={DISTANCE_COLORS["70.3"]}
+          />
+        )}
+        {show1406 && (
+          <DistanceSection
+            label="IRONMAN"
+            races={races1406}
+            color={DISTANCE_COLORS["140.6"]}
+          />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/src/lib/data.ts
+++ b/app/src/lib/data.ts
@@ -202,12 +202,23 @@ export function getAthleteProfile(slug: string): AthleteProfile | null {
     fullName = result.fullName;
     country = result.country;
     countryISO = result.countryISO;
+
+    const allFinishTimes = getAllResults(raceSlug).map((r) => r.finishSeconds).filter((s) => s > 0);
+    const slowerCount = allFinishTimes.filter((s) => s > result.finishSeconds).length;
+    const overallPercentile = allFinishTimes.length > 0
+      ? Math.round((slowerCount / allFinishTimes.length) * 100)
+      : 0;
+    const distance: "70.3" | "140.6" = raceSlug.startsWith("im703-") ? "70.3" : "140.6";
+
     races.push({
       raceSlug: race.slug,
       raceName: race.name,
       raceDate: race.date,
       resultId: result.id,
       finishTime: result.finishTime,
+      finishSeconds: result.finishSeconds,
+      overallPercentile,
+      distance,
       ageGroup: result.ageGroup,
       swimTime: result.swimTime,
       bikeTime: result.bikeTime,

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -56,6 +56,9 @@ export interface AthleteRaceEntry {
   raceDate: string;
   resultId: number;
   finishTime: string;
+  finishSeconds: number;
+  overallPercentile: number;
+  distance: "70.3" | "140.6";
   ageGroup: string;
   swimTime: string;
   bikeTime: string;


### PR DESCRIPTION
## Summary

- Adds a new `AthletePerformanceCharts` client component with line charts showing finish time and finish percentile over time, separated by race distance (IRONMAN 70.3 and IRONMAN 140.6)
- Extends `AthleteRaceEntry` with `finishSeconds`, `overallPercentile`, and `distance` fields; `getAthleteProfile` now computes these per race
- Charts are rendered below the race cards list and only shown when an athlete has 2+ results for a given distance
- Race cards now display a distance badge (70.3/140.6) and overall percentile

Closes #24

## Test plan

- [ ] Navigate to an athlete page with multiple 70.3 results and confirm finish time + percentile charts appear below the race cards
- [ ] Confirm charts are hidden for distance categories with fewer than 2 results
- [ ] Confirm tooltips show race name, date, and formatted value on hover
- [ ] Run `npm run build` and confirm no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)