### PR TITLE
Fix course page colors and limit to 10 courses per discipline

### DIFF
--- a/app/src/app/courses/course-charts.tsx
+++ b/app/src/app/courses/course-charts.tsx
@@ -2,28 +2,29 @@
 
 import { useState } from "react";
 import type { CourseStats } from "@/lib/types";
+import { DISCIPLINE_COLORS } from "@/lib/colors";
 import CourseBarChart from "@/components/CourseBarChart";
 
 const DISCIPLINES = [
   {
     key: "medianFinishSeconds" as const,
     label: "Overall",
-    color: "#22c55e",
+    color: DISCIPLINE_COLORS.Total,
   },
   {
     key: "medianSwimSeconds" as const,
     label: "Swim",
-    color: "#3b82f6",
+    color: DISCIPLINE_COLORS.Swim,
   },
   {
     key: "medianBikeSeconds" as const,
     label: "Bike",
-    color: "#ef4444",
+    color: DISCIPLINE_COLORS.Bike,
   },
   {
     key: "medianRunSeconds" as const,
     label: "Run",
-    color: "#f59e0b",
+    color: DISCIPLINE_COLORS.Run,
   },
 ];
 
@@ -57,10 +58,6 @@ export default function CourseCharts({
           </button>
         ))}
       </div>
-
-      <p className="text-sm text-gray-500 mb-6">
-        {filtered.length} courses
-      </p>
 
       <div className="space-y-8">
         {DISCIPLINES.map((disc) => (

--- a/app/src/app/race/[slug]/page.tsx
+++ b/app/src/app/race/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { formatTime } from "@/lib/format";
 import { getCountryFlagISO } from "@/lib/flags";
 import ResultCard from "@/components/ResultCard";
 import RaceHistogram from "@/components/RaceHistogram";
+import { DISCIPLINE_COLORS } from "@/lib/colors";
 
 // Generate on demand — too many races to pre-render at build time.
 export async function generateStaticParams() {
@@ -14,13 +15,6 @@ export async function generateStaticParams() {
 interface PageProps {
   params: Promise<{ slug: string }>;
 }
-
-const DISCIPLINE_COLORS: Record<string, string> = {
-  Swim: "#3b82f6",
-  Bike: "#ef4444",
-  Run: "#f59e0b",
-  Total: "#22c55e",
-};
 
 export default async function RacePage({ params }: PageProps) {
   const { slug } = await params;

--- a/app/src/components/CourseBarChart.tsx
+++ b/app/src/components/CourseBarChart.tsx
@@ -23,6 +23,8 @@ type DisciplineKey =
   | "medianBikeSeconds"
   | "medianRunSeconds";
 
+const MAX_COURSES = 10;
+
 interface Props {
   courses: CourseStats[];
   disciplineKey: DisciplineKey;
@@ -38,7 +40,8 @@ export default function CourseBarChart({
 }: Props) {
   const sorted = [...courses]
     .filter((c) => c[disciplineKey] > 0)
-    .sort((a, b) => a[disciplineKey] - b[disciplineKey]);
+    .sort((a, b) => a[disciplineKey] - b[disciplineKey])
+    .slice(0, MAX_COURSES);
 
   if (sorted.length === 0) return null;
 


### PR DESCRIPTION
## Summary
- Use canonical `DISCIPLINE_COLORS` from `colors.ts` across the codebase
- Fixed Overall/Total color from green to gray per design guidelines
- Limited course charts to show the top 10 courses per discipline
- Removed misleading course count that didn't reflect the limited display

## Changes
- `courses/course-charts.tsx`: Import and use canonical colors, remove course count display
- `race/[slug]/page.tsx`: Import canonical colors, remove duplicate definition
- `CourseBarChart.tsx`: Limit sorted results to 10 courses per discipline

🤖 Generated with [Claude Code](https://claude.com/claude-code)