### PR TITLE
feat: add course count cards to stats page

### DIFF
--- a/app/src/app/stats/page.tsx
+++ b/app/src/app/stats/page.tsx
@@ -33,6 +33,18 @@ export default function StatsPage() {
           </p>
         </div>
         <div className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">
+          <p className="text-sm text-gray-400">IRONMAN Courses</p>
+          <p className="text-3xl font-bold text-white mt-1">
+            {stats.ironmanCourseCount.toLocaleString()}
+          </p>
+        </div>
+        <div className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">
+          <p className="text-sm text-gray-400">IRONMAN 70.3 Courses</p>
+          <p className="text-3xl font-bold text-white mt-1">
+            {stats.halfIronmanCourseCount.toLocaleString()}
+          </p>
+        </div>
+        <div className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">
           <p className="text-sm text-gray-400">Earliest Race</p>
           <Link
             href={`/race/${stats.earliestRace.slug}`}

--- a/app/src/lib/data.ts
+++ b/app/src/lib/data.ts
@@ -257,6 +257,8 @@ export interface StatsPageData {
   raceCount: number;
   totalResults: number;
   uniqueAthletes: number;
+  ironmanCourseCount: number;
+  halfIronmanCourseCount: number;
   earliestRace: { slug: string; name: string; date: string };
   mostRecentRace: { slug: string; name: string; date: string };
 }
@@ -267,10 +269,23 @@ export function getStatsPageData(): StatsPageData {
   const earliest = sorted[0];
   const mostRecent = sorted[sorted.length - 1];
 
+  const ironmanCourses = new Set<string>();
+  const halfIronmanCourses = new Set<string>();
+  for (const r of races) {
+    const base = r.slug.replace(/-\d{4}$/, "");
+    if (r.slug.startsWith("im703-")) {
+      halfIronmanCourses.add(base);
+    } else {
+      ironmanCourses.add(base);
+    }
+  }
+
   return {
     raceCount: races.length,
     totalResults: races.reduce((sum, r) => sum + r.finishers, 0),
     uniqueAthletes: getDeduplicatedAthleteIndex().length,
+    ironmanCourseCount: ironmanCourses.size,
+    halfIronmanCourseCount: halfIronmanCourses.size,
     earliestRace: { slug: earliest.slug, name: earliest.name, date: earliest.date },
     mostRecentRace: { slug: mostRecent.slug, name: mostRecent.name, date: mostRecent.date },
   };


### PR DESCRIPTION
Add separate stat cards for IRONMAN and IRONMAN 70.3 courses to the stats page.

## Summary
- Added `ironmanCourseCount` and `halfIronmanCourseCount` to `StatsPageData` interface
- Updated `getStatsPageData()` to compute unique course counts (16 IRONMAN, 30 70.3 courses)
- Added two new stat cards to display these counts alongside existing stats

Unique courses are determined by stripping year suffixes (e.g., -2025) from race slugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)