### PR TITLE
style: simplify race cards design

### DIFF
--- a/app/src/app/races/race-list.tsx
+++ b/app/src/app/races/race-list.tsx
@@ -14,19 +14,12 @@ function formatDate(iso: string): string {
   });
 }
 
-function getDistanceInfo(slug: string): { label: string; color: string; accent: string } {
-  if (slug.startsWith("im703-")) {
-    return {
-      label: "70.3",
-      color: "bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/30",
-      accent: "border-l-blue-500",
-    };
-  }
-  return {
-    label: "140.6",
-    color: "bg-orange-500/20 text-orange-400 ring-1 ring-orange-500/30",
-    accent: "border-l-orange-500",
-  };
+function getDistanceLabel(slug: string): string {
+  return slug.startsWith("im703-") ? "70.3" : "140.6";
+}
+
+function cleanRaceName(name: string): string {
+  return name.replace(/^IRONMAN\s+70\.3\s+/i, "").replace(/^IRONMAN\s+/i, "");
 }
 
 function getYear(date: string): string {
@@ -86,21 +79,20 @@ export default function RaceList({ races }: { races: RaceInfo[] }) {
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {filtered.map((race) => {
-          const dist = getDistanceInfo(race.slug);
           const flag = getCountryFlag(race.location);
 
           return (
             <Link
               key={race.slug}
               href={`/race/${race.slug}`}
-              className={`group block p-5 border border-gray-700/80 border-l-4 ${dist.accent} rounded-lg bg-gray-900 transition-all duration-200 hover:border-gray-600 hover:bg-gray-800/80 hover:shadow-lg hover:shadow-black/20 hover:-translate-y-0.5`}
+              className="group block p-5 border border-gray-700/80 rounded-lg bg-gray-900 transition-colors duration-200 hover:border-gray-600 hover:bg-gray-800/80"
             >
               <div className="flex items-start justify-between gap-3">
                 <h2 className="text-lg font-semibold text-white group-hover:text-blue-300 transition-colors leading-tight">
-                  {race.name}
+                  {cleanRaceName(race.name)}
                 </h2>
-                <span className={`shrink-0 px-2 py-0.5 rounded-full text-xs font-bold ${dist.color}`}>
-                  {dist.label}
+                <span className="shrink-0 px-2 py-0.5 rounded-full text-xs font-medium bg-white/5 text-gray-400">
+                  {getDistanceLabel(race.slug)}
                 </span>
               </div>
 
@@ -109,12 +101,10 @@ export default function RaceList({ races }: { races: RaceInfo[] }) {
                 {race.location}
               </p>
 
-              <div className="flex items-center gap-3 mt-3 text-xs text-gray-500">
+              <div className="flex items-center gap-2 mt-3 text-xs text-gray-500">
                 <span>{formatDate(race.date)}</span>
                 <span className="text-gray-700">&middot;</span>
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-800 text-gray-400">
-                  {race.finishers.toLocaleString()} finishers
-                </span>
+                <span>{race.finishers.toLocaleString()} finishers</span>
               </div>
             </Link>
           );


### PR DESCRIPTION
Remove redundant "IRONMAN" branding from race titles, replace colored distance badges with monochrome styling, remove the colored left border accent, and simplify the finisher count layout. This reduces visual noise and makes the card grid more scannable while maintaining all essential information.