### PR TITLE
feat: add ability to toggle race results on athlete profile

### DIFF
--- a/app/src/app/athlete/[slug]/page.tsx
+++ b/app/src/app/athlete/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getAthleteProfile } from "@/lib/data";
 import { getCountryFlagISO } from "@/lib/flags";
-import AthletePerformanceCharts from "@/components/AthletePerformanceCharts";
+import AthleteRaceList from "@/components/AthleteRaceList";
 
 export async function generateStaticParams() {
   return [];
@@ -35,45 +35,7 @@ export default async function AthletePage({ params }: PageProps) {
         </p>
       </header>
 
-      <div className="space-y-4">
-        {profile.races.map((race) => (
-          <Link
-            key={`${race.raceSlug}-${race.resultId}`}
-            href={`/race/${race.raceSlug}/result/${race.resultId}`}
-            className="block bg-gray-900 border border-gray-800 rounded-lg px-5 py-4 hover:border-gray-600 transition-colors"
-          >
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="flex items-center gap-2">
-                  <span className="font-medium text-white">{race.raceName}</span>
-                  <span className={`text-xs font-bold px-2 py-0.5 rounded-full ${
-                    race.distance === "70.3"
-                      ? "bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/30"
-                      : "bg-orange-500/20 text-orange-400 ring-1 ring-orange-500/30"
-                  }`}>
-                    {race.distance}
-                  </span>
-                </div>
-                <div className="text-sm text-gray-400 mt-1">
-                  {race.raceDate} &middot; {race.ageGroup} &middot; Faster than {race.overallPercentile}%
-                </div>
-              </div>
-              <div className="text-right">
-                <div className="text-lg font-mono text-white">{race.finishTime}</div>
-                <div className="text-xs font-mono text-gray-500 mt-1">
-                  <span className="text-blue-400">{race.swimTime}</span>
-                  {" / "}
-                  <span className="text-red-400">{race.bikeTime}</span>
-                  {" / "}
-                  <span className="text-amber-400">{race.runTime}</span>
-                </div>
-              </div>
-            </div>
-          </Link>
-        ))}
-      </div>
-
-      <AthletePerformanceCharts races={[...profile.races].reverse()} />
+      <AthleteRaceList slug={slug} races={profile.races} />
     </main>
   );
 }

--- a/app/src/components/AthleteRaceList.tsx
+++ b/app/src/components/AthleteRaceList.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import type { AthleteRaceEntry } from "@/lib/types";
+import AthletePerformanceCharts from "./AthletePerformanceCharts";
+
+interface Props {
+  slug: string;
+  races: AthleteRaceEntry[];
+}
+
+function raceKey(race: AthleteRaceEntry): string {
+  return `${race.raceSlug}:${race.resultId}`;
+}
+
+function storageKey(slug: string): string {
+  return `tritimes:hidden-races:${slug}`;
+}
+
+function loadHidden(slug: string): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = localStorage.getItem(storageKey(slug));
+    if (raw) return new Set(JSON.parse(raw));
+  } catch {}
+  return new Set();
+}
+
+function saveHidden(slug: string, hidden: Set<string>) {
+  try {
+    if (hidden.size === 0) {
+      localStorage.removeItem(storageKey(slug));
+    } else {
+      localStorage.setItem(storageKey(slug), JSON.stringify([...hidden]));
+    }
+  } catch {}
+}
+
+export default function AthleteRaceList({ slug, races }: Props) {
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    setHidden(loadHidden(slug));
+  }, [slug]);
+
+  const toggle = useCallback(
+    (key: string) => {
+      setHidden((prev) => {
+        const next = new Set(prev);
+        if (next.has(key)) {
+          next.delete(key);
+        } else {
+          next.add(key);
+        }
+        saveHidden(slug, next);
+        return next;
+      });
+    },
+    [slug],
+  );
+
+  const visibleRaces = races.filter((r) => !hidden.has(raceKey(r)));
+  const hasHidden = hidden.size > 0;
+
+  return (
+    <>
+      <div className="space-y-4">
+        {races.map((race) => {
+          const key = raceKey(race);
+          const isHidden = hidden.has(key);
+
+          return (
+            <div
+              key={key}
+              className={`flex items-center bg-gray-900 border rounded-lg transition-colors ${
+                isHidden
+                  ? "border-gray-800/50 opacity-50"
+                  : "border-gray-800 hover:border-gray-600"
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => toggle(key)}
+                className="flex-shrink-0 p-3 pl-4 text-gray-500 hover:text-gray-300 transition-colors"
+                title={isHidden ? "Show in charts" : "Hide from charts"}
+                aria-label={
+                  isHidden
+                    ? `Show ${race.raceName} in charts`
+                    : `Hide ${race.raceName} from charts`
+                }
+              >
+                {isHidden ? <EyeOffIcon /> : <EyeIcon />}
+              </button>
+              <Link
+                href={`/race/${race.raceSlug}/result/${race.resultId}`}
+                className="block flex-1 min-w-0 px-3 py-4 pr-5"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-white truncate">
+                        {race.raceName}
+                      </span>
+                      <span
+                        className={`flex-shrink-0 text-xs font-bold px-2 py-0.5 rounded-full ${
+                          race.distance === "70.3"
+                            ? "bg-blue-500/20 text-blue-400 ring-1 ring-blue-500/30"
+                            : "bg-orange-500/20 text-orange-400 ring-1 ring-orange-500/30"
+                        }`}
+                      >
+                        {race.distance}
+                      </span>
+                    </div>
+                    <div className="text-sm text-gray-400 mt-1">
+                      {race.raceDate} &middot; {race.ageGroup} &middot; Faster
+                      than {race.overallPercentile}%
+                    </div>
+                  </div>
+                  <div className="text-right flex-shrink-0 ml-4">
+                    <div className="text-lg font-mono text-white">
+                      {race.finishTime}
+                    </div>
+                    <div className="text-xs font-mono text-gray-500 mt-1">
+                      <span className="text-blue-400">{race.swimTime}</span>
+                      {" / "}
+                      <span className="text-red-400">{race.bikeTime}</span>
+                      {" / "}
+                      <span className="text-amber-400">{race.runTime}</span>
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            </div>
+          );
+        })}
+      </div>
+
+      {hasHidden && (
+        <p className="text-sm text-gray-500 mt-2">
+          {hidden.size} {hidden.size === 1 ? "result" : "results"} hidden from
+          charts
+        </p>
+      )}
+
+      <AthletePerformanceCharts races={[...visibleRaces].reverse()} />
+    </>
+  );
+}
+
+function EyeIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+function EyeOffIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49" />
+      <path d="M14.084 14.158a3 3 0 0 1-4.242-4.242" />
+      <path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143" />
+      <path d="m2 2 20 20" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Athletes can now selectively hide race results from the performance charts on their profile page. Each race card displays an eye icon toggle button on the left side that allows hiding/showing individual results. Hidden selections persist in localStorage, so the athlete's choices survive page refreshes.

## Changes

- New `AthleteRaceList` client component manages the race card list and visibility state
- Charts regenerate client-side to only include visible races  
- Added eye/eye-off SVG icons for clear visual feedback
- Improved card layout to prevent icon overlap with finish times
- No performance impact since all data is already sent to the client

## Testing

The feature works across all athlete profile pages where multiple people share the same name (like Thomas Edwards). Athletes can toggle off results that don't belong to them to get accurate performance trends.

🤖 Generated with Claude Code