### PR TITLE
feat: add CSV export for athlete race results

### DIFF
--- a/app/src/app/athlete/[slug]/page.tsx
+++ b/app/src/app/athlete/[slug]/page.tsx
@@ -31,7 +31,7 @@ export default async function AthletePage({ params }: PageProps) {
         </p>
       </header>
 
-      <AthleteRaceList slug={slug} races={profile.races} />
+      <AthleteRaceList slug={slug} fullName={profile.fullName} races={profile.races} />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
Athletes can now download their race history as a CSV file from their profile page. The export includes race name, date, distance, age group, discipline splits, finish time, and performance percentile.

Closes #29

## Implementation
- Added "Export CSV" button to athlete profile page
- Client-side CSV generation using Blob API with proper field escaping
- Filename uses athlete's name (e.g., `jan-frodeno-results.csv`)

🤖 Generated with Claude Code