### PR TITLE
fix: export only visible races to CSV

### DIFF
--- a/app/src/components/AthleteRaceList.tsx
+++ b/app/src/components/AthleteRaceList.tsx
@@ -109,7 +109,7 @@ export default function AthleteRaceList({ slug, fullName, races }: Props) {
       <div className="flex justify-end mb-4">
         <button
           type="button"
-          onClick={() => downloadCsv(fullName, races)}
+          onClick={() => downloadCsv(fullName, visibleRaces)}
           className="flex items-center gap-1.5 text-sm text-gray-400 hover:text-white transition-colors cursor-pointer"
         >
           <DownloadIcon />


### PR DESCRIPTION
## Summary
Fixed the CSV export to respect hidden races. When users hide races via the eye icon on the athlete profile, those races are now excluded from the export.

## Changes
- Modified `AthleteRaceList` to pass `visibleRaces` (filtered) instead of `races` (unfiltered) to the `downloadCsv` function

🤖 Generated with [Claude Code](https://claude.com/claude-code)