### PR TITLE
fix: remove duplicate race name and back arrows from result pages

### DIFF
--- a/app/src/app/race/[slug]/page.tsx
+++ b/app/src/app/race/[slug]/page.tsx
@@ -37,10 +37,6 @@ export default async function RacePage({ params }: PageProps) {
 
   return (
     <main className="max-w-6xl mx-auto px-4 py-8">
-      <Link href="/races" className="text-blue-400 hover:underline text-sm mb-6 inline-block">
-        &larr; All races
-      </Link>
-
       <header className="mb-8">
         <h1 className="text-3xl font-bold text-white">{race.name}</h1>
         <p className="text-gray-400 mt-1">

--- a/app/src/app/race/[slug]/result/[id]/page.tsx
+++ b/app/src/app/race/[slug]/result/[id]/page.tsx
@@ -62,17 +62,13 @@ export default async function ResultPage({ params }: PageProps) {
 
   return (
     <main className="max-w-6xl mx-auto px-4 py-8">
-      <Link href={`/race/${slug}`} className="text-blue-400 hover:underline text-sm mb-6 inline-block">
-        &larr; {race.name}
-      </Link>
-
       <header className="mb-8">
         <h1 className="text-3xl font-bold text-white">
           {flag && <span className="mr-2">{flag}</span>}
           {athlete.fullName}
         </h1>
         <p className="text-gray-400 mt-1">
-          {race.name} &middot; Bib #{athlete.bib} &middot; {athlete.ageGroup} &middot; {location}
+          <Link href={`/race/${slug}`} className="text-blue-400 hover:underline">{race.name}</Link> &middot; Bib #{athlete.bib} &middot; {athlete.ageGroup} &middot; {location}
         </p>
       </header>
 


### PR DESCRIPTION
## Summary

Eliminates duplicate race name displays and back arrows for cleaner navigation. On the result page, the race name now appears once as a clickable link within the metadata line. The standalone back link with arrow has been removed from the race detail page.

Fixes #65

## Changes

- Remove standalone back link from race detail page
- Remove standalone back link from athlete result page
- Make race name in result page metadata a clickable link to the race page