### PR TITLE
feat: improve courses page layout and consistent container widths

### DIFF
--- a/app/src/app/athlete/[slug]/loading.tsx
+++ b/app/src/app/athlete/[slug]/loading.tsx
@@ -1,6 +1,6 @@
 export default function Loading() {
   return (
-    <main className="max-w-6xl mx-auto px-4 py-8 animate-pulse">
+    <main className="max-w-6xl w-full mx-auto px-4 py-8 animate-pulse">
       {/* Back link */}
       <div className="h-4 w-28 bg-gray-800 rounded mb-6" />
 

--- a/app/src/app/athlete/[slug]/page.tsx
+++ b/app/src/app/athlete/[slug]/page.tsx
@@ -20,7 +20,7 @@ export default async function AthletePage({ params }: PageProps) {
   const flag = getCountryFlagISO(profile.countryISO);
 
   return (
-    <main className="max-w-6xl mx-auto px-4 py-8">
+    <main className="max-w-6xl w-full mx-auto px-4 py-8">
       <header className="mb-8">
         <h1 className="text-3xl font-bold text-white">
           {flag && <span className="mr-2">{flag}</span>}

--- a/app/src/app/courses/course-charts.tsx
+++ b/app/src/app/courses/course-charts.tsx
@@ -59,7 +59,7 @@ export default function CourseCharts({
         ))}
       </div>
 
-      <div className="space-y-8">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {DISCIPLINES.map((disc) => (
           <CourseBarChart
             key={disc.key}

--- a/app/src/app/courses/page.tsx
+++ b/app/src/app/courses/page.tsx
@@ -11,12 +11,11 @@ export default function CoursesPage() {
   const courses = getCourseStats();
 
   return (
-    <main className="max-w-6xl mx-auto px-4 py-8">
+    <main className="max-w-6xl w-full mx-auto px-4 py-8">
       <header className="mb-8">
         <h1 className="text-3xl font-bold text-white">Course Difficulty</h1>
         <p className="text-gray-400 mt-1">
-          Courses ranked by median time — fastest at the top, slowest at the
-          bottom.
+          Top 10 fastest courses per discipline, ranked by median time.
         </p>
       </header>
       <CourseCharts courses={courses} />

--- a/app/src/app/race/[slug]/page.tsx
+++ b/app/src/app/race/[slug]/page.tsx
@@ -36,7 +36,7 @@ export default async function RacePage({ params }: PageProps) {
   const finishStats = stats.disciplines.find((d) => d.discipline === "Total");
 
   return (
-    <main className="max-w-6xl mx-auto px-4 py-8">
+    <main className="max-w-6xl w-full mx-auto px-4 py-8">
       <header className="mb-8">
         <h1 className="text-3xl font-bold text-white">{race.name}</h1>
         <p className="text-gray-400 mt-1">

--- a/app/src/app/race/[slug]/result/[id]/loading.tsx
+++ b/app/src/app/race/[slug]/result/[id]/loading.tsx
@@ -1,6 +1,6 @@
 export default function Loading() {
   return (
-    <main className="max-w-6xl mx-auto px-4 py-8 animate-pulse">
+    <main className="max-w-6xl w-full mx-auto px-4 py-8 animate-pulse">
       {/* Back link */}
       <div className="h-4 w-28 bg-gray-800 rounded mb-6" />
 

--- a/app/src/app/race/[slug]/result/[id]/page.tsx
+++ b/app/src/app/race/[slug]/result/[id]/page.tsx
@@ -61,7 +61,7 @@ export default async function ResultPage({ params }: PageProps) {
 
 
   return (
-    <main className="max-w-6xl mx-auto px-4 py-8">
+    <main className="max-w-6xl w-full mx-auto px-4 py-8">
       <header className="mb-8">
         <h1 className="text-3xl font-bold text-white">
           {flag && <span className="mr-2">{flag}</span>}

--- a/app/src/app/races/page.tsx
+++ b/app/src/app/races/page.tsx
@@ -5,7 +5,7 @@ export default function RacesPage() {
   const races = getRaces();
 
   return (
-    <main className="max-w-6xl mx-auto px-4 py-8">
+    <main className="max-w-6xl w-full mx-auto px-4 py-8">
       <h1 className="text-3xl font-bold text-white mb-8">All Races</h1>
       <RaceList races={races} />
     </main>

--- a/app/src/app/stats/page.tsx
+++ b/app/src/app/stats/page.tsx
@@ -11,7 +11,7 @@ export default function StatsPage() {
   const stats = getStatsPageData();
 
   return (
-    <main className="max-w-6xl mx-auto px-4 py-8">
+    <main className="max-w-6xl w-full mx-auto px-4 py-8">
       <h1 className="text-3xl font-bold text-white mb-8">Stats</h1>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         <div className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">


### PR DESCRIPTION
## Summary
- Display course difficulty charts in a 2-column grid layout for better horizontal space utilization
- Updated courses page copy to clarify "Top 10 fastest courses per discipline"
- Fixed flex layout issues by adding w-full to all main containers
- Applied consistent max-w-6xl container width across all pages

## Changes
- **Courses page**: 2-column grid for charts, improved description
- **All pages**: Added w-full to ensure containers properly fill available space (courses, races, athlete, results, stats)

🤖 Generated with [Claude Code](https://claude.com/claude-code)