### PR TITLE
refactor: reduce UI clutter on result cards

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -17,7 +17,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "TriTimes — Triathlon Result Distributions",
+  title: "TriTimes — Triathlon Times",
   description:
     "View your IronMan 70.3 triathlon results with statistical distributions for swim, bike, run, and total time.",
 };

--- a/app/src/components/AthleteRaceList.tsx
+++ b/app/src/components/AthleteRaceList.tsx
@@ -133,7 +133,7 @@ export default function AthleteRaceList({ slug, fullName, races }: Props) {
               <button
                 type="button"
                 onClick={() => toggle(key)}
-                className="flex-shrink-0 p-3 pl-4 pt-4 text-gray-500 hover:text-gray-300 transition-colors"
+                className="flex-shrink-0 p-3 pl-4 self-center text-gray-500 hover:text-gray-300 transition-colors"
                 title={isHidden ? "Show in charts" : "Hide from charts"}
                 aria-label={
                   isHidden

--- a/app/src/components/Histogram.tsx
+++ b/app/src/components/Histogram.tsx
@@ -27,11 +27,8 @@ export default function Histogram({ data, color, label }: Props) {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-2">
+      <div className="mb-2">
         <span className="text-sm font-medium text-gray-400">{label}</span>
-        <span className="text-sm font-semibold" style={{ color }}>
-          Faster than {data.athletePercentile}%
-        </span>
       </div>
       <ResponsiveContainer width="100%" height={200}>
         <BarChart data={data.bins} margin={{ top: 5, right: 10, bottom: 5, left: 0 }}>


### PR DESCRIPTION
Streamlines the result cards and histograms by removing visual noise and improving alignment.

- Shorten page title to fit better in browser tabs
- Vertically center eye icon on athlete race cards
- Remove "Faster than X%" percentile text from histogram labels

🤖 Generated with Claude Code