### PR TITLE
feat: add search analytics to track athlete selections

### DIFF
--- a/app/src/components/CommandPalette.tsx
+++ b/app/src/components/CommandPalette.tsx
@@ -8,7 +8,7 @@ import { getCountryFlagISO } from "@/lib/flags";
 
 export default function CommandPalette() {
   const [isOpen, setIsOpen] = useState(false);
-  const { query, matches, isSearching, selectedIndex, setSelectedIndex, handleChange, reset } =
+  const { query, matches, isSearching, selectedIndex, setSelectedIndex, handleChange, trackSelect, reset } =
     useAthleteSearch();
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -90,6 +90,7 @@ export default function CommandPalette() {
       setSelectedIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === "Enter" && selectedIndex >= 0) {
       e.preventDefault();
+      trackSelect(matches[selectedIndex]);
       router.push(`/athlete/${matches[selectedIndex].slug}`);
       close();
     }
@@ -170,7 +171,10 @@ export default function CommandPalette() {
               >
                 <Link
                   href={`/athlete/${entry.slug}`}
-                  onClick={close}
+                  onClick={() => {
+                    trackSelect(entry);
+                    close();
+                  }}
                   className="flex items-center gap-3 px-4 py-3"
                   tabIndex={-1}
                 >

--- a/app/src/components/GlobalSearchBar.tsx
+++ b/app/src/components/GlobalSearchBar.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { useAthleteSearch } from "@/hooks/useAthleteSearch";
 
 export default function GlobalSearchBar() {
-  const { query, matches, isSearching, selectedIndex, setSelectedIndex, handleChange } =
+  const { query, matches, isSearching, selectedIndex, setSelectedIndex, handleChange, trackSelect } =
     useAthleteSearch();
   const [isOpen, setIsOpen] = useState(false);
   const router = useRouter();
@@ -41,6 +41,7 @@ export default function GlobalSearchBar() {
       setSelectedIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === "Enter" && selectedIndex >= 0) {
       e.preventDefault();
+      trackSelect(matches[selectedIndex]);
       handleSelect();
       router.push(`/athlete/${matches[selectedIndex].slug}`);
     } else if (e.key === "Escape") {
@@ -77,7 +78,10 @@ export default function GlobalSearchBar() {
             >
               <Link
                 href={`/athlete/${entry.slug}`}
-                onClick={() => handleSelect()}
+                onClick={() => {
+                  trackSelect(entry);
+                  handleSelect();
+                }}
                 className="block px-4 py-3"
               >
                 <div className="font-medium text-white">{entry.fullName}</div>

--- a/app/src/hooks/useAthleteSearch.ts
+++ b/app/src/hooks/useAthleteSearch.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
+import { track } from "@vercel/analytics";
 import { AthleteSearchEntry } from "@/lib/types";
 
 export function useAthleteSearch() {
@@ -53,6 +54,13 @@ export function useAthleteSearch() {
     }, 150);
   }, []);
 
+  const trackSelect = useCallback(
+    (athlete: AthleteSearchEntry) => {
+      track("search_select", { query, athlete: athlete.fullName });
+    },
+    [query],
+  );
+
   const reset = useCallback(() => {
     setQuery("");
     setMatches([]);
@@ -69,6 +77,7 @@ export function useAthleteSearch() {
     selectedIndex,
     setSelectedIndex,
     handleChange,
+    trackSelect,
     reset,
   };
 }


### PR DESCRIPTION
## Summary

Add Vercel Analytics custom events to track which athletes users select from the search interface. This provides insights into popular searches and helps identify search patterns.

## Changes

- Added `trackSelect()` callback to `useAthleteSearch` hook that fires a `search_select` custom event
- Integrated analytics tracking in both `GlobalSearchBar` and `CommandPalette` components
- Event includes the search query and selected athlete name as properties

## Test plan

- Search for an athlete in the global search bar and select a result
- Search for an athlete using Cmd+K command palette and select a result
- Verify that `search_select` events appear in Vercel Analytics dashboard with correct query and athlete properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)