### PR TITLE
fix: close command palette on outside click

### DIFF
--- a/app/src/components/CommandPalette.tsx
+++ b/app/src/components/CommandPalette.tsx
@@ -13,6 +13,7 @@ export default function CommandPalette() {
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   const close = useCallback(() => {
     setIsOpen(false);
@@ -100,8 +101,8 @@ export default function CommandPalette() {
   return (
     <div
       className="fixed inset-0 z-[60] flex items-start justify-center pt-[15vh]"
-      onClick={(e) => {
-        if (e.target === e.currentTarget) close();
+      onMouseDown={(e) => {
+        if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) close();
       }}
       role="dialog"
       aria-modal="true"
@@ -111,7 +112,7 @@ export default function CommandPalette() {
       <div className="fixed inset-0 bg-black/60 backdrop-blur-sm -z-10" />
 
       {/* Dialog */}
-      <div className="w-full max-w-lg mx-4 bg-gray-900 border border-gray-700 rounded-xl shadow-2xl overflow-hidden animate-in">
+      <div ref={dialogRef} className="w-full max-w-lg mx-4 bg-gray-900 border border-gray-700 rounded-xl shadow-2xl overflow-hidden animate-in">
         {/* Search input */}
         <div className="flex items-center gap-3 px-4 py-3">
           <svg


### PR DESCRIPTION
## Summary
- Fix the Cmd+K command palette to close when clicking outside the dialog
- Use ref-based containment check instead of `e.target === e.currentTarget` which failed when clicks hit the backdrop child element
- Switch from `onClick` to `onMouseDown` for more responsive dismissal