### PR TITLE
fix: reduce serverless function size by gzipping CSV files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ data/raw/
 data/athlete-index.json*
 data/athlete-profiles.json*
 data/course-stats.json*
+data/*.csv.gz
 .DS_Store

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -1,7 +1,8 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  outputFileTracingRoot: path.join(import.meta.dirname, ".."),
 };
 
 export default nextConfig;

--- a/app/src/lib/data.ts
+++ b/app/src/lib/data.ts
@@ -100,11 +100,10 @@ function parseCSV(raceSlug: string): AthleteResult[] {
   const cached = cache.get(raceSlug);
   if (cached) return cached;
 
-  const csvFile = `${raceSlug}.csv`;
-  const csvPath = path.join(process.cwd(), "..", "data", csvFile);
-  if (!fs.existsSync(csvPath)) return [];
+  const gzPath = path.join(process.cwd(), "..", "data", `${raceSlug}.csv.gz`);
+  if (!fs.existsSync(gzPath)) return [];
 
-  const raw = fs.readFileSync(csvPath, "utf-8");
+  const raw = gunzipSync(fs.readFileSync(gzPath)).toString("utf-8");
   const rows = parseCSVRows(raw);
   if (rows.length === 0) return [];
 

--- a/scripts/build-search-index.js
+++ b/scripts/build-search-index.js
@@ -227,6 +227,17 @@ const courseStats = Array.from(courseMap.values()).map((c) => ({
 
 fs.writeFileSync(courseStatsPath, gzipSync(JSON.stringify(courseStats)));
 
+// ── Gzip CSV files for compact serverless deployment ─────────────
+
+let gzCount = 0;
+for (const race of races) {
+  const csvPath = path.join(dataDir, `${race.slug}.csv`);
+  if (!fs.existsSync(csvPath)) continue;
+  const raw = fs.readFileSync(csvPath);
+  fs.writeFileSync(`${csvPath}.gz`, gzipSync(raw));
+  gzCount++;
+}
+
 const elapsed = Date.now() - start;
 console.log(
   `Built search index: ${searchIndex.length} athletes in ${elapsed}ms → ${path.relative(process.cwd(), searchIndexPath)}`
@@ -236,4 +247,7 @@ console.log(
 );
 console.log(
   `Built course stats: ${courseStats.length} courses → ${path.relative(process.cwd(), courseStatsPath)}`
+);
+console.log(
+  `Gzipped ${gzCount} CSV files for deployment`
 );


### PR DESCRIPTION
## Summary

Gzip all 574 CSV files at build time (`scripts/build-search-index.js`) and read compressed versions at runtime (`app/src/lib/data.ts`). This reduces the data footprint in serverless bundles from 232MB to 81MB, staying well under Vercel's 250MB limit.

The build script now generates `.csv.gz` files, which are traced into serverless functions instead of raw CSVs. Decompression uses `gunzipSync` (already a dependency) and results are cached in memory—negligible performance impact.

## Changes

- **scripts/build-search-index.js**: Gzip all 574 CSVs after building search indexes
- **app/src/lib/data.ts**: Read `.csv.gz` files instead of raw `.csv` 
- **app/next.config.ts**: Set `outputFileTracingRoot` to repo root for correct data file tracing
- **.gitignore**: Ignore generated `.csv.gz` files (created at build time)

## Test Plan

- ✅ Full build completes successfully
- ✅ All 10 CSV parsing tests pass
- ✅ Raw CSVs no longer traced into serverless bundles
- ✅ Gzipped CSVs properly traced and decompressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)