### PR TITLE
fix: show search spinner and add missing loading skeletons

### DIFF
--- a/app/src/app/courses/loading.tsx
+++ b/app/src/app/courses/loading.tsx
@@ -1,0 +1,21 @@
+export default function Loading() {
+  return (
+    <main className="max-w-6xl w-full mx-auto px-4 py-8 animate-pulse">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="h-8 w-56 bg-gray-800 rounded mb-2" />
+        <div className="h-4 w-80 bg-gray-800 rounded" />
+      </div>
+
+      {/* Chart cards */}
+      <div className="space-y-8">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div key={i} className="border border-gray-800 rounded-lg p-6">
+            <div className="h-6 w-40 bg-gray-800 rounded mb-4" />
+            <div className="h-64 bg-gray-800 rounded" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/src/app/stats/loading.tsx
+++ b/app/src/app/stats/loading.tsx
@@ -1,0 +1,63 @@
+export default function Loading() {
+  return (
+    <main className="max-w-6xl w-full mx-auto px-4 py-8 animate-pulse">
+      {/* Title */}
+      <div className="h-8 w-24 bg-gray-800 rounded mb-8" />
+
+      {/* Overview section */}
+      <div className="h-6 w-28 bg-gray-800 rounded mb-4" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        {Array.from({ length: 9 }, (_, i) => (
+          <div key={i} className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">
+            <div className="h-4 w-32 bg-gray-800 rounded mb-3" />
+            <div className="h-8 w-20 bg-gray-800 rounded" />
+          </div>
+        ))}
+      </div>
+
+      {/* Race Size section */}
+      <div className="h-6 w-28 bg-gray-800 rounded mb-4" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        {Array.from({ length: 3 }, (_, i) => (
+          <div key={i} className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">
+            <div className="h-4 w-32 bg-gray-800 rounded mb-3" />
+            <div className="h-8 w-20 bg-gray-800 rounded" />
+          </div>
+        ))}
+      </div>
+
+      {/* Geography section */}
+      <div className="h-6 w-32 bg-gray-800 rounded mb-4" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div key={i} className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">
+            <div className="h-4 w-32 bg-gray-800 rounded mb-3" />
+            <div className="h-8 w-20 bg-gray-800 rounded" />
+          </div>
+        ))}
+      </div>
+
+      {/* Finish Times section */}
+      <div className="h-6 w-48 bg-gray-800 rounded mb-4" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+        {Array.from({ length: 2 }, (_, i) => (
+          <div key={i} className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">
+            <div className="h-4 w-32 bg-gray-800 rounded mb-3" />
+            <div className="h-8 w-20 bg-gray-800 rounded" />
+          </div>
+        ))}
+      </div>
+
+      {/* Demographics section */}
+      <div className="h-6 w-36 bg-gray-800 rounded mb-4" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div key={i} className="p-5 border border-gray-700/80 rounded-lg bg-gray-900">
+            <div className="h-4 w-32 bg-gray-800 rounded mb-3" />
+            <div className="h-8 w-20 bg-gray-800 rounded" />
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/src/hooks/useAthleteSearch.ts
+++ b/app/src/hooks/useAthleteSearch.ts
@@ -33,6 +33,7 @@ export function useAthleteSearch() {
     }
 
     if (debounceRef.current) clearTimeout(debounceRef.current);
+    setIsSearching(true);
     debounceRef.current = setTimeout(async () => {
       const key = value.toLowerCase();
       const cached = cacheRef.current.get(key);
@@ -45,7 +46,6 @@ export function useAthleteSearch() {
       abortRef.current?.abort();
       const controller = new AbortController();
       abortRef.current = controller;
-      setIsSearching(true);
 
       try {
         const res = await fetch(`/api/search?q=${encodeURIComponent(value)}`, {


### PR DESCRIPTION
## Summary
- Fix search spinner not showing: moved `setIsSearching(true)` before the debounce timeout so the spinner appears immediately when the user types, not after the 50ms debounce + API response
- Add `loading.tsx` skeletons for `/courses` and `/stats` pages (the only two pages missing them)

## Test plan
- [x] Type in search bar — spinner should appear immediately
- [ ] Navigate to `/courses` — loading skeleton should flash before content
- [ ] Navigate to `/stats` — loading skeleton should flash before content

🤖 Generated with [Claude Code](https://claude.com/claude-code)