### PR TITLE
perf: cache ISR pages indefinitely to cut Vercel writes

### DIFF
--- a/app/src/app/athlete/[slug]/page.tsx
+++ b/app/src/app/athlete/[slug]/page.tsx
@@ -7,8 +7,9 @@ export async function generateStaticParams() {
   return [];
 }
 
-// Athlete data is static once scraped — cache rendered pages for 1 hour.
-export const revalidate = 3600;
+// Athlete data is immutable once scraped — cache indefinitely. Cache is
+// reset on each deploy, which is when new CSVs land.
+export const revalidate = false;
 
 interface PageProps {
   params: Promise<{ slug: string }>;

--- a/app/src/app/race/[slug]/page.tsx
+++ b/app/src/app/race/[slug]/page.tsx
@@ -16,8 +16,9 @@ export async function generateStaticParams() {
   return [];
 }
 
-// Race data is static once scraped — cache rendered pages for 1 hour.
-export const revalidate = 3600;
+// Race data is immutable once scraped — cache indefinitely. Cache is
+// reset on each deploy, which is when new CSVs land.
+export const revalidate = false;
 
 interface PageProps {
   params: Promise<{ slug: string }>;

--- a/app/src/app/race/[slug]/result/[id]/page.tsx
+++ b/app/src/app/race/[slug]/result/[id]/page.tsx
@@ -29,8 +29,9 @@ export async function generateStaticParams() {
   return [];
 }
 
-// Race data is static once scraped — cache rendered pages for 1 hour.
-export const revalidate = 3600;
+// Race results are immutable once scraped — cache indefinitely. Cache is
+// reset on each deploy, which is when new CSVs land.
+export const revalidate = false;
 
 interface PageProps {
   params: Promise<{ slug: string; id: string }>;

--- a/app/src/app/races/page.tsx
+++ b/app/src/app/races/page.tsx
@@ -1,7 +1,7 @@
 import { getRaces } from "@/lib/data";
 import RaceList from "./race-list";
 
-export const revalidate = 3600;
+export const revalidate = false;
 
 export default function RacesPage() {
   const races = getRaces();


### PR DESCRIPTION
## Summary

- Switched `revalidate` from `3600` (1 hour) to `false` (cache indefinitely) on the four dynamic routes: `/race/[slug]`, `/race/[slug]/result/[id]`, `/athlete/[slug]`, and `/races`.
- Race data is immutable once scraped; new data only ships through a redeploy, which resets the ISR cache anyway. The 1-hour window was producing repeat writes for the same unchanging pages.

## Why

On May 10 Vercel logged ~119k ISR writes for tritimes — ~60% of the 200k/month free-tier budget in a single day. With ~1.4k race CSVs and millions of result URLs, a crawler sweep regenerates the same pages every hour under the old config. With `revalidate = false` each unique page is written once per deploy.

## Risk

If someone edits a CSV without redeploying, the change won't appear until the next deploy. That's already how the pipeline works in practice (CSVs are committed to git, deploys happen on push), so no behavior change for the maintainer workflow.

## Test plan

- [ ] Confirm pages render correctly after deploy (open a race page, a result page, an athlete page)
- [ ] Watch Vercel ISR Writes graph over the next 7 days — expect a sharp drop from baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)