### PR TITLE
feat: add robots.ts and sitemap.ts to control crawler reach

### DIFF
--- a/app/src/app/robots.ts
+++ b/app/src/app/robots.ts
@@ -1,0 +1,38 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = "https://tritimes.org";
+
+// AI training crawlers that have produced spikes of unique-URL traffic on
+// data-heavy sites. Blocking them keeps ISR writes bounded and the site's
+// content out of unattributed model training corpora.
+const BLOCKED_AI_AGENTS = [
+  "GPTBot",
+  "ChatGPT-User",
+  "OAI-SearchBot",
+  "ClaudeBot",
+  "anthropic-ai",
+  "Claude-Web",
+  "PerplexityBot",
+  "CCBot",
+  "Bytespider",
+  "Amazonbot",
+  "Applebot-Extended",
+  "Google-Extended",
+  "FacebookBot",
+  "Meta-ExternalAgent",
+  "cohere-ai",
+  "Diffbot",
+  "ImagesiftBot",
+  "Omgilibot",
+];
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      { userAgent: "*", allow: "/", disallow: "/api/" },
+      ...BLOCKED_AI_AGENTS.map((userAgent) => ({ userAgent, disallow: "/" })),
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/app/src/app/sitemap.ts
+++ b/app/src/app/sitemap.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from "next";
+import { getRaces } from "@/lib/data";
+
+const SITE_URL = "https://tritimes.org";
+
+// Individual result and athlete pages are intentionally excluded. The site
+// has millions of those URLs and listing them encourages crawlers to walk
+// the whole graph — each first visit costs an ISR write. Crawlers can still
+// discover them organically via links from race pages if they choose to.
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+  const races = getRaces();
+
+  const indexPages: MetadataRoute.Sitemap = [
+    { url: `${SITE_URL}/`, lastModified: now, changeFrequency: "weekly", priority: 1 },
+    { url: `${SITE_URL}/races`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${SITE_URL}/courses`, lastModified: now, changeFrequency: "monthly", priority: 0.6 },
+    { url: `${SITE_URL}/stats`, lastModified: now, changeFrequency: "weekly", priority: 0.6 },
+  ];
+
+  const racePages: MetadataRoute.Sitemap = races.map((race) => ({
+    url: `${SITE_URL}/race/${race.slug}`,
+    lastModified: race.date ? new Date(race.date) : now,
+    changeFrequency: "yearly",
+    priority: 0.5,
+  }));
+
+  return [...indexPages, ...racePages];
+}


### PR DESCRIPTION
## Summary

- Adds `app/src/app/robots.ts` — disallows the noisy AI training crawlers (GPTBot, ClaudeBot, CCBot, PerplexityBot, Bytespider, Google-Extended, Applebot-Extended, etc.) and points everyone at the sitemap.
- Adds `app/src/app/sitemap.ts` — lists the four index pages (`/`, `/races`, `/courses`, `/stats`) plus one entry per race (~1.4k URLs).
- Intentionally omits result and athlete pages from the sitemap. There are millions of those, and listing them encourages crawlers to walk the whole graph, where each first visit produces an ISR write.

## Why

Companion to #178 (`revalidate = false`). That PR caps how often each page re-writes; this PR caps how aggressively crawlers discover new pages in the first place. Well-behaved search engines get an explicit hub-and-spoke map (index pages → race pages) and can follow links from there if they want individual results. AI training crawlers get blocked outright.

## Notes

- `SITE_URL` is hardcoded to `https://tritimes.org`. If a staging/preview domain ever needs its own robots policy, switch to an env var.
- Blocking `Google-Extended` and `Applebot-Extended` opts the site out of those vendors' AI training corpora without affecting their search indexing.

## Test plan

- [ ] After deploy, fetch `https://tritimes.org/robots.txt` and confirm the AI-agent block list
- [ ] Fetch `https://tritimes.org/sitemap.xml` and confirm it lists the index pages and race pages
- [ ] Watch Vercel ISR Writes for a 7-day baseline shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)