### PR TITLE
perf: lazy-mount command palette and defer search prefetch

### DIFF
--- a/app/src/components/CommandPalette.tsx
+++ b/app/src/components/CommandPalette.tsx
@@ -3,11 +3,11 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { useAthleteSearch } from "@/hooks/useAthleteSearch";
+import { useAthleteSearch, prefetchSearch } from "@/hooks/useAthleteSearch";
 import { getCountryFlagISO } from "@/lib/flags";
 
-export default function CommandPalette() {
-  const [isOpen, setIsOpen] = useState(false);
+export default function CommandPalette({ defaultOpen = false }: { defaultOpen?: boolean }) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
   const { query, matches, isSearching, selectedIndex, setSelectedIndex, handleChange, trackSelect, reset } =
     useAthleteSearch();
   const router = useRouter();
@@ -49,9 +49,10 @@ export default function CommandPalette() {
     };
   }, [reset, isOpen, close]);
 
-  // Focus input when opened
+  // Focus input + warm the search function when opened
   useEffect(() => {
     if (isOpen) {
+      prefetchSearch();
       requestAnimationFrame(() => inputRef.current?.focus());
     }
   }, [isOpen]);

--- a/app/src/components/GlobalSearchBar.tsx
+++ b/app/src/components/GlobalSearchBar.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { useAthleteSearch } from "@/hooks/useAthleteSearch";
+import { useAthleteSearch, prefetchSearch } from "@/hooks/useAthleteSearch";
 
 export default function GlobalSearchBar() {
   const { query, matches, isSearching, selectedIndex, setSelectedIndex, handleChange, trackSelect } =
@@ -57,7 +57,10 @@ export default function GlobalSearchBar() {
           value={query}
           onChange={(e) => handleChange(e.target.value)}
           onKeyDown={handleKeyDown}
-          onFocus={() => matches.length > 0 && setIsOpen(true)}
+          onFocus={() => {
+            prefetchSearch();
+            if (matches.length > 0) setIsOpen(true);
+          }}
           placeholder="Search athlete name..."
           className="w-full px-4 py-3 text-lg border border-gray-700 rounded-lg bg-gray-900 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
         />

--- a/app/src/components/LazyCommandPalette.tsx
+++ b/app/src/components/LazyCommandPalette.tsx
@@ -1,11 +1,36 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
 
 const CommandPalette = dynamic(() => import("./CommandPalette"), {
   ssr: false,
 });
 
 export default function LazyCommandPalette() {
-  return <CommandPalette />;
+  // Defer loading the palette chunk (and its useAthleteSearch dep) until the
+  // user first reaches for it. Saves a chunk + listeners on every page entry.
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    if (mounted) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setMounted(true);
+      }
+    }
+    function onOpenEvent() {
+      setMounted(true);
+    }
+    document.addEventListener("keydown", onKeyDown);
+    window.addEventListener("open-command-palette", onOpenEvent);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("open-command-palette", onOpenEvent);
+    };
+  }, [mounted]);
+
+  if (!mounted) return null;
+  return <CommandPalette defaultOpen />;
 }

--- a/app/src/hooks/useAthleteSearch.ts
+++ b/app/src/hooks/useAthleteSearch.ts
@@ -4,11 +4,13 @@ import { useState, useRef, useCallback } from "react";
 import { track } from "@vercel/analytics";
 import { AthleteSearchEntry } from "@/lib/types";
 
-// Warm the search serverless function on first module load.
-// Uses a short query to trigger index decompression without transferring much data.
-let prefetchStarted = false;
-if (typeof window !== "undefined" && !prefetchStarted) {
-  prefetchStarted = true;
+// Warm the search serverless function on first user intent (focus/open),
+// not on module import — importing this hook on every route otherwise costs
+// a network round-trip during hydration.
+let prefetched = false;
+export function prefetchSearch() {
+  if (prefetched || typeof window === "undefined") return;
+  prefetched = true;
   fetch("/api/search?q=a", { priority: "low" }).catch(() => {});
 }
 


### PR DESCRIPTION
## Summary
- Removed the module-level `fetch("/api/search?q=a")` from `useAthleteSearch.ts`. Replaced with an exported `prefetchSearch()` helper that runs at most once, only when called.
- `GlobalSearchBar` now calls `prefetchSearch()` on input focus; `CommandPalette` calls it when the palette opens.
- `LazyCommandPalette` now owns the ⌘K / `open-command-palette` listeners and only mounts the `CommandPalette` chunk on first trigger (passing `defaultOpen` so it opens immediately).

Net effect: every non-homepage route ships zero search-related JS at hydration time — no `useAthleteSearch` module on import, no `CommandPalette` chunk, no eager `/api/search` fetch competing with LCP. The lambda is still warmed before the user types, just gated to focus/open instead of mount. Targets INP and TTFB contributions to Vercel Real Experience Score.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] `npm test` (vitest) — 22 tests pass, including the new `getGlobalSearchViewState` suite from main
- [x] Smoke spec: ⌘K and header search button both mount-and-open the palette; typing returns results

## Merge resolution (2026-05-14)
Merged latest `main` to resolve conflicts in `GlobalSearchBar.tsx` and `useAthleteSearch.ts` (from #174 and #103). Kept both the new `getGlobalSearchViewState` view-state logic and request-id tracking from main; combined them with this PR's `prefetchSearch()` on input focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)