### PR TITLE
perf: stream result page header before histogram work

### DIFF
--- a/app/src/app/race/[slug]/result/[id]/page.tsx
+++ b/app/src/app/race/[slug]/result/[id]/page.tsx
@@ -1,28 +1,10 @@
+import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { getRaceBySlug, getAthleteById, getDisciplineHistogram, getGenderCount, getAgeGroupCount, getAllResults, type Discipline } from "@/lib/data";
-import dynamic from "next/dynamic";
+import { getRaceBySlug, getAthleteById, getGenderCount, getAgeGroupCount, getAllResults } from "@/lib/data";
 import ResultCard from "@/components/ResultCard";
 import { getCountryFlagISO } from "@/lib/flags";
-
-const DisciplineSections = dynamic(
-  () => import("@/components/DisciplineSections"),
-  {
-    loading: () => (
-      <div className="space-y-6 animate-pulse">
-        <div className="flex justify-center"><div className="h-10 w-56 bg-gray-800 rounded-lg" /></div>
-        {[1, 2, 3, 4].map((i) => (
-          <div key={i} className="bg-gray-900 rounded-xl border border-gray-700 p-6">
-            <div className="h-5 w-24 bg-gray-800 rounded mb-4" />
-            <div className="h-48 bg-gray-800 rounded" />
-          </div>
-        ))}
-      </div>
-    ),
-  }
-);
-import { DISCIPLINE_COLORS, DEFAULT_DISCIPLINE_COLOR } from "@/lib/colors";
-import PercentilePill from "@/components/PercentilePill";
+import HistogramSection, { HistogramSectionFallback } from "@/components/HistogramSection";
 import ShareDialog from "@/components/ShareDialog";
 
 // Don't pre-render all 75K+ athlete pages at build time — generate on demand.
@@ -46,30 +28,6 @@ export default async function ResultPage({ params }: PageProps) {
 
   const athlete = getAthleteById(slug, Number(id));
   if (!athlete) notFound();
-
-  const disciplines: { key: Discipline; label: string; time: string }[] = [
-    { key: "swim", label: "Swim", time: athlete.swimTime },
-    { key: "bike", label: "Bike", time: athlete.bikeTime },
-    { key: "run", label: "Run", time: athlete.runTime },
-    { key: "finish", label: "Total", time: athlete.finishTime },
-  ];
-
-  const transitions: { key: Discipline; label: string; time: string }[] = [
-    { key: "t1", label: "T1", time: athlete.t1Time },
-    { key: "t2", label: "T2", time: athlete.t2Time },
-  ];
-
-  const histograms = disciplines.map((d) => ({
-    ...d,
-    overall: getDisciplineHistogram(slug, athlete, d.key, "overall"),
-    ageGroup: getDisciplineHistogram(slug, athlete, d.key, "ageGroup"),
-  }));
-
-  const transitionHistograms = transitions.map((d) => ({
-    ...d,
-    overall: getDisciplineHistogram(slug, athlete, d.key, "overall"),
-    ageGroup: getDisciplineHistogram(slug, athlete, d.key, "ageGroup"),
-  }));
 
   const totalFinishers = getAllResults(slug).length;
   const genderTotal = getGenderCount(slug, athlete.gender);
@@ -119,28 +77,9 @@ export default async function ResultPage({ params }: PageProps) {
         />
       </div>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-        {histograms.map((d) => (
-          <div
-            key={d.key}
-            className="relative bg-gray-900 rounded-lg border border-gray-700 p-4 text-center"
-          >
-            <div className="absolute top-2 right-2">
-              <PercentilePill percentile={d.ageGroup.athletePercentile} />
-            </div>
-            <div className="text-sm font-medium mb-1" style={{ color: DISCIPLINE_COLORS[d.label] || DEFAULT_DISCIPLINE_COLOR }}>
-              {d.label}
-            </div>
-            <div className="text-lg font-mono font-bold text-white">{d.time}</div>
-          </div>
-        ))}
-      </div>
-
-      <DisciplineSections
-        disciplines={histograms}
-        transitions={transitionHistograms}
-        ageGroup={athlete.ageGroup}
-      />
+      <Suspense fallback={<HistogramSectionFallback />}>
+        <HistogramSection slug={slug} athlete={athlete} />
+      </Suspense>
     </main>
   );
 }

--- a/app/src/components/HistogramSection.tsx
+++ b/app/src/components/HistogramSection.tsx
@@ -1,0 +1,105 @@
+import dynamic from "next/dynamic";
+import {
+  getDisciplineHistogram,
+  preloadHistograms,
+  type Discipline,
+} from "@/lib/data";
+import type { AthleteResult } from "@/lib/types";
+import { DISCIPLINE_COLORS, DEFAULT_DISCIPLINE_COLOR } from "@/lib/colors";
+import PercentilePill from "./PercentilePill";
+
+const DisciplineSections = dynamic(() => import("./DisciplineSections"));
+
+interface Props {
+  slug: string;
+  athlete: AthleteResult;
+}
+
+export default async function HistogramSection({ slug, athlete }: Props) {
+  // Awaited I/O gives the React renderer a yield point: the parent server
+  // component flushes its HTML to the browser before histogram work runs.
+  await preloadHistograms(slug);
+
+  const disciplines: { key: Discipline; label: string; time: string }[] = [
+    { key: "swim", label: "Swim", time: athlete.swimTime },
+    { key: "bike", label: "Bike", time: athlete.bikeTime },
+    { key: "run", label: "Run", time: athlete.runTime },
+    { key: "finish", label: "Total", time: athlete.finishTime },
+  ];
+
+  const transitions: { key: Discipline; label: string; time: string }[] = [
+    { key: "t1", label: "T1", time: athlete.t1Time },
+    { key: "t2", label: "T2", time: athlete.t2Time },
+  ];
+
+  const histograms = disciplines.map((d) => ({
+    ...d,
+    overall: getDisciplineHistogram(slug, athlete, d.key, "overall"),
+    ageGroup: getDisciplineHistogram(slug, athlete, d.key, "ageGroup"),
+  }));
+
+  const transitionHistograms = transitions.map((d) => ({
+    ...d,
+    overall: getDisciplineHistogram(slug, athlete, d.key, "overall"),
+    ageGroup: getDisciplineHistogram(slug, athlete, d.key, "ageGroup"),
+  }));
+
+  return (
+    <>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+        {histograms.map((d) => (
+          <div
+            key={d.key}
+            className="relative bg-gray-900 rounded-lg border border-gray-700 p-4 text-center"
+          >
+            <div className="absolute top-2 right-2">
+              <PercentilePill percentile={d.ageGroup.athletePercentile} />
+            </div>
+            <div
+              className="text-sm font-medium mb-1"
+              style={{ color: DISCIPLINE_COLORS[d.label] || DEFAULT_DISCIPLINE_COLOR }}
+            >
+              {d.label}
+            </div>
+            <div className="text-lg font-mono font-bold text-white">{d.time}</div>
+          </div>
+        ))}
+      </div>
+
+      <DisciplineSections
+        disciplines={histograms}
+        transitions={transitionHistograms}
+        ageGroup={athlete.ageGroup}
+      />
+    </>
+  );
+}
+
+export function HistogramSectionFallback() {
+  return (
+    <>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8" aria-hidden>
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="bg-gray-900 rounded-lg border border-gray-700 p-4 text-center animate-pulse"
+          >
+            <div className="h-4 w-12 bg-gray-800 rounded mx-auto mb-2" />
+            <div className="h-6 w-20 bg-gray-800 rounded mx-auto" />
+          </div>
+        ))}
+      </div>
+      <div className="space-y-6 animate-pulse" aria-hidden>
+        <div className="flex justify-center">
+          <div className="h-10 w-56 bg-gray-800 rounded-lg" />
+        </div>
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="bg-gray-900 rounded-xl border border-gray-700 p-6">
+            <div className="h-5 w-24 bg-gray-800 rounded mb-4" />
+            <div className="h-48 bg-gray-800 rounded" />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/app/src/lib/data.ts
+++ b/app/src/lib/data.ts
@@ -510,6 +510,22 @@ function loadPrecomputedHistograms(raceSlug: string) {
   return data;
 }
 
+// Async variant for streaming server components: the awaited disk I/O gives
+// React's renderer a yield point so the parent shell can flush before the
+// downstream sync histogram work runs.
+export async function preloadHistograms(raceSlug: string): Promise<void> {
+  if (histogramCache.has(raceSlug)) return;
+
+  const histPath = path.join(process.cwd(), "..", "data", "histograms", `${raceSlug}.json.gz`);
+  try {
+    const buf = await fs.promises.readFile(histPath);
+    const data = JSON.parse(gunzipSync(buf).toString());
+    histogramCache.set(raceSlug, data);
+  } catch {
+    // File missing — getDisciplineHistogram will fall back to on-demand compute
+  }
+}
+
 export function getDisciplineHistogram(
   raceSlug: string,
   athlete: AthleteResult,


### PR DESCRIPTION
## Summary
- Added `preloadHistograms(slug)` to `lib/data.ts` — an async wrapper around the precomputed-histogram file read. The awaited `fs.promises.readFile` gives React's renderer a real yield point during disk I/O so the parent server component can flush its HTML before histogram work runs.
- Extracted `HistogramSection` (async server component): awaits the preload, then renders the 4 discipline summary cards + `DisciplineSections`.
- Result page now renders the LCP shell (header + 3 overview `ResultCard`s) synchronously and wraps `HistogramSection` in `<Suspense>` with a CLS-stable skeleton fallback (`HistogramSectionFallback`).

Net effect: on cold visits to a result page (the deepest, most-shared URLs), the athlete name + overall percentile cards reach the browser as soon as the CSV is parsed — without waiting on the second gzipped JSON read for histograms. Targets LCP + TTFB contributions to Vercel Real Experience Score.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] `npm test` (vitest) — 22 tests pass
- [x] `npm run build` — production build clean, result route still SSG
- [x] **Streaming verified**: streamed curl on a cold-cache race showed the shell + fallback flushed at +37ms (~22KB), then the resolved histogram chunk + React `$RC` reveal at +46ms — a measurable streaming gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)