### PR TITLE
ci(scrape): auto-merge the daily race-results PR

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -77,3 +77,7 @@ jobs:
             --head "$BRANCH" \
             --title "feat: add new race results" \
             --body-file /tmp/pr-body.md
+
+          # Request auto-merge so the PR squash-merges once CI passes,
+          # instead of piling up as a stale daily backlog.
+          gh pr merge "$BRANCH" --auto --squash --delete-branch


### PR DESCRIPTION
## Summary
The daily scraper workflow creates a PR every morning but never schedules a merge — that's why 77 stale `auto/scrape-*` PRs piled up between 2026-02-27 and 2026-05-14 before the backlog was cleared. Two things are required to fix it; this PR is the second:

1. **Done separately:** flipped `allow_auto_merge` to `true` at the repo level (it was `false`, which would silently reject any `--auto` request even if the workflow asked).
2. **This PR:** add `gh pr merge --auto --squash --delete-branch` after `gh pr create` in `.github/workflows/scrape.yml`, so each day's scraper PR squash-merges itself the moment CI goes green and cleans up its branch.

CI is already green on every scraper run going back, so there's no expected blocker — the daily PR will simply land within minutes of being opened.

## Test plan
- [x] Manual diff review: one-line addition after `gh pr create`
- [ ] After merge, manually dispatch the `scrape.yml` workflow (`gh workflow run scrape.yml`) and confirm:
  - the resulting PR enters "auto-merge enabled" state
  - it merges once CI passes
  - the `auto/scrape-YYYY-MM-DD` branch is deleted
- [ ] Alternatively, wait for tomorrow's 06:00 UTC cron run

🤖 Generated with [Claude Code](https://claude.com/claude-code)