### PR TITLE
perf: client-side athlete index for instant search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ data/histograms/
 .claude/worktrees
 .claude/*.local.json
 .superpowers/
+app/public/athlete-index.tsv.gz

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -23,6 +23,19 @@ const nextConfig: NextConfig = {
           },
         ],
       },
+      {
+        source: "/athlete-index.tsv.gz",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=300, stale-while-revalidate=604800",
+          },
+          {
+            key: "Content-Type",
+            value: "application/gzip",
+          },
+        ],
+      },
     ];
   },
 };

--- a/app/package.json
+++ b/app/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "node ../scripts/copy-search-index.js",
     "dev": "next dev",
-    "build": "node ../scripts/gzip-csvs.js && node ../scripts/build-histograms.js && next build",
+    "build": "node ../scripts/gzip-csvs.js && node ../scripts/build-histograms.js && node ../scripts/copy-search-index.js && next build",
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",

--- a/app/src/components/CommandPalette.tsx
+++ b/app/src/components/CommandPalette.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { useAthleteSearch, prefetchSearch } from "@/hooks/useAthleteSearch";
+import { useAthleteSearch, prefetchSearchIndex } from "@/hooks/useAthleteSearch";
 import { getCountryFlagISO } from "@/lib/flags";
 
 export default function CommandPalette({ defaultOpen = false }: { defaultOpen?: boolean }) {
@@ -52,7 +52,7 @@ export default function CommandPalette({ defaultOpen = false }: { defaultOpen?: 
   // Focus input + warm the search function when opened
   useEffect(() => {
     if (isOpen) {
-      prefetchSearch();
+      prefetchSearchIndex();
       requestAnimationFrame(() => inputRef.current?.focus());
     }
   }, [isOpen]);

--- a/app/src/components/GlobalSearchBar.tsx
+++ b/app/src/components/GlobalSearchBar.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { useAthleteSearch, prefetchSearch } from "@/hooks/useAthleteSearch";
+import { useAthleteSearch, prefetchSearchIndex } from "@/hooks/useAthleteSearch";
 import { AthleteSearchEntry } from "@/lib/types";
 
 export type GlobalSearchViewState = "closed" | "loading" | "empty" | "results";
@@ -35,6 +35,10 @@ export default function GlobalSearchBar() {
     }
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    prefetchSearchIndex();
   }, []);
 
   // Sync isOpen with the active search state.
@@ -73,7 +77,7 @@ export default function GlobalSearchBar() {
           onChange={(e) => handleChange(e.target.value)}
           onKeyDown={handleKeyDown}
           onFocus={() => {
-            prefetchSearch();
+            prefetchSearchIndex();
             if (viewState !== "closed") setIsOpen(true);
           }}
           placeholder="Search athlete name..."

--- a/app/src/hooks/useAthleteSearch.ts
+++ b/app/src/hooks/useAthleteSearch.ts
@@ -3,15 +3,32 @@
 import { useState, useRef, useCallback } from "react";
 import { track } from "@vercel/analytics";
 import { AthleteSearchEntry } from "@/lib/types";
+import {
+  loadSearchIndex,
+  searchAthletesInClientIndex,
+  type ClientSearchIndex,
+} from "@/lib/client-search-index";
 
-// Warm the search serverless function on first user intent (focus/open),
-// not on module import — importing this hook on every route otherwise costs
-// a network round-trip during hydration.
 let prefetched = false;
-export function prefetchSearch() {
+let cachedIndex: ClientSearchIndex | null = null;
+
+export function prefetchSearchIndex() {
   if (prefetched || typeof window === "undefined") return;
   prefetched = true;
-  fetch("/api/search?q=a", { priority: "low" }).catch(() => {});
+  loadSearchIndex().then(
+    (index) => {
+      cachedIndex = index;
+      track("search_index_load", {
+        download_ms: Math.round(index.loadStats.downloadMs),
+        parse_ms: Math.round(index.loadStats.parseMs),
+        bytes: index.loadStats.bytes,
+      });
+    },
+    (err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      track("search_index_load_error", { message });
+    },
+  );
 }
 
 export function useAthleteSearch() {
@@ -21,7 +38,9 @@ export function useAthleteSearch() {
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const abortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const cacheRef = useRef(new Map<string, AthleteSearchEntry[]>());
+  const cacheRef = useRef(
+    new Map<string, { results: AthleteSearchEntry[]; source: "client" | "api" }>()
+  );
   const requestIdRef = useRef(0);
 
   const handleChange = useCallback((value: string) => {
@@ -40,16 +59,38 @@ export function useAthleteSearch() {
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
     setIsSearching(true);
+    const startedAt = performance.now();
     debounceRef.current = setTimeout(async () => {
       if (requestIdRef.current !== requestId) return;
 
       const key = value.toLowerCase();
-      const cached = cacheRef.current.get(key);
-      if (cached) {
-        setMatches(cached);
+      const cacheEntry = cacheRef.current.get(key);
+      if (cacheEntry) {
+        setMatches(cacheEntry.results);
+        if (requestIdRef.current === requestId) setIsSearching(false);
+        track("search_latency", {
+          latency_ms: Math.round(performance.now() - startedAt),
+          query_length: value.length,
+          source: cacheEntry.source,
+          cached: true,
+        });
+        return;
+      }
+
+      if (cachedIndex) {
+        const results = searchAthletesInClientIndex(value, cachedIndex, 10);
+        cacheRef.current.set(key, { results, source: "client" });
         if (requestIdRef.current === requestId) {
+          setMatches(results);
           setIsSearching(false);
+          abortRef.current?.abort();
         }
+        track("search_latency", {
+          latency_ms: Math.round(performance.now() - startedAt),
+          query_length: value.length,
+          source: "client",
+          cached: false,
+        });
         return;
       }
 
@@ -63,10 +104,16 @@ export function useAthleteSearch() {
           signal: controller.signal,
         });
         const data: AthleteSearchEntry[] = await res.json();
-        cacheRef.current.set(key, data);
+        cacheRef.current.set(key, { results: data, source: "api" });
         if (requestIdRef.current === requestId) {
           setMatches(data);
         }
+        track("search_latency", {
+          latency_ms: Math.round(performance.now() - startedAt),
+          query_length: value.length,
+          source: "api",
+          cached: false,
+        });
       } catch {
         // Aborted or network error — ignore
       } finally {

--- a/app/src/lib/__tests__/client-search-index.test.ts
+++ b/app/src/lib/__tests__/client-search-index.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parseIndexTsv } from "../client-search-index";
+
+describe("parseIndexTsv", () => {
+  it("parses one line into one IndexEntry", () => {
+    const tsv = "john-smith\tJohn Smith\tUnited States\tUS\t4";
+    expect(parseIndexTsv(tsv)).toEqual([
+      {
+        slug: "john-smith",
+        fullName: "John Smith",
+        fullNameLower: "john smith",
+        country: "United States",
+        countryISO: "US",
+        raceCount: 4,
+      },
+    ]);
+  });
+
+  it("parses multiple lines and skips blanks", () => {
+    const tsv = [
+      "alicia-goldsmith\tAlicia Goldsmith\tUnited States\tUS\t1",
+      "",
+      "zoe-jones\tZoe Jones\tAustralia\tAU\t3",
+    ].join("\n");
+    const entries = parseIndexTsv(tsv);
+    expect(entries.map((e) => e.slug)).toEqual(["alicia-goldsmith", "zoe-jones"]);
+  });
+
+  it("lowercases fullName into fullNameLower", () => {
+    const tsv = "x\tFoo BAR\tx\tXX\t1";
+    expect(parseIndexTsv(tsv)[0].fullNameLower).toBe("foo bar");
+  });
+
+  it("parses raceCount as a number", () => {
+    const tsv = "x\tx\tx\tXX\t42";
+    expect(parseIndexTsv(tsv)[0].raceCount).toBe(42);
+  });
+});

--- a/app/src/lib/__tests__/client-search-index.test.ts
+++ b/app/src/lib/__tests__/client-search-index.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
-import { parseIndexTsv } from "../client-search-index";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { parseIndexTsv, loadSearchIndex, __resetForTests } from "../client-search-index";
+import { gzipSync } from "node:zlib";
+import { Readable } from "node:stream";
 
 describe("parseIndexTsv", () => {
   it("parses one line into one IndexEntry", () => {
@@ -34,5 +36,46 @@ describe("parseIndexTsv", () => {
   it("parses raceCount as a number", () => {
     const tsv = "x\tx\tx\tXX\t42";
     expect(parseIndexTsv(tsv)[0].raceCount).toBe(42);
+  });
+});
+
+function makeGzippedResponse(tsv: string): Response {
+  const buf = gzipSync(tsv);
+  return new Response(Readable.toWeb(Readable.from([buf])) as ReadableStream, {
+    status: 200,
+    headers: { "Content-Type": "application/gzip" },
+  });
+}
+
+describe("loadSearchIndex memoization", () => {
+  beforeEach(() => {
+    __resetForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches the index only once across concurrent callers", async () => {
+    const tsv = "john-smith\tJohn Smith\tUnited States\tUS\t4";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(makeGzippedResponse(tsv));
+
+    const [a, b] = await Promise.all([loadSearchIndex(), loadSearchIndex()]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+    expect(a.entries.map((e) => e.slug)).toEqual(["john-smith"]);
+  });
+
+  it("caches a rejection so callers do not retry", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("network"));
+
+    await expect(loadSearchIndex()).rejects.toThrow("network");
+    await expect(loadSearchIndex()).rejects.toThrow("network");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/src/lib/__tests__/search-core.bench.ts
+++ b/app/src/lib/__tests__/search-core.bench.ts
@@ -1,0 +1,45 @@
+import { bench, describe } from "vitest";
+import { gunzipSync } from "node:zlib";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { buildSearchKeys, searchAthletesInIndex, type IndexEntry } from "../search-core";
+
+function loadFixture(): IndexEntry[] {
+  const path = join(process.cwd(), "..", "data", "athlete-index.tsv.gz");
+  const tsv = gunzipSync(readFileSync(path)).toString();
+  const lines = tsv.split("\n");
+  const entries: IndexEntry[] = [];
+  for (const line of lines) {
+    if (!line) continue;
+    const t1 = line.indexOf("\t");
+    const t2 = line.indexOf("\t", t1 + 1);
+    const t3 = line.indexOf("\t", t2 + 1);
+    const t4 = line.indexOf("\t", t3 + 1);
+    const fullName = line.substring(t1 + 1, t2);
+    entries.push({
+      slug: line.substring(0, t1),
+      fullName,
+      fullNameLower: fullName.toLowerCase(),
+      country: line.substring(t2 + 1, t3),
+      countryISO: line.substring(t3 + 1, t4),
+      raceCount: +line.substring(t4 + 1),
+    });
+  }
+  return entries;
+}
+
+const entries = loadFixture();
+const keys = buildSearchKeys(entries);
+const queries = ["jo", "smi", "rod", "ros", "anders", "wang", "li", "müller", "smith j", "garcia"];
+
+describe("search-core", () => {
+  bench(
+    "searchAthletesInIndex (10 mixed queries)",
+    () => {
+      for (const q of queries) {
+        searchAthletesInIndex(q, entries, keys, 10);
+      }
+    },
+    { iterations: 1000 },
+  );
+});

--- a/app/src/lib/__tests__/search-core.test.ts
+++ b/app/src/lib/__tests__/search-core.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSearchKeys,
+  searchAthletesInIndex,
+  type IndexEntry,
+} from "../search-core";
+
+const athletes: IndexEntry[] = [
+  {
+    slug: "alicia-goldsmith",
+    fullName: "Alicia Goldsmith",
+    fullNameLower: "alicia goldsmith",
+    country: "United States",
+    countryISO: "US",
+    raceCount: 1,
+  },
+  {
+    slug: "john-smith",
+    fullName: "John Smith",
+    fullNameLower: "john smith",
+    country: "United States",
+    countryISO: "US",
+    raceCount: 4,
+  },
+  {
+    slug: "sarah-smith",
+    fullName: "Sarah Smith",
+    fullNameLower: "sarah smith",
+    country: "Canada",
+    countryISO: "CA",
+    raceCount: 2,
+  },
+  {
+    slug: "zoe-jones",
+    fullName: "Zoe Jones",
+    fullNameLower: "zoe jones",
+    country: "Australia",
+    countryISO: "AU",
+    raceCount: 3,
+  },
+];
+const keys = buildSearchKeys(athletes);
+
+describe("searchAthletesInIndex (core)", () => {
+  it("finds first-name prefix matches", () => {
+    expect(searchAthletesInIndex("john", athletes, keys)).toMatchObject([
+      { slug: "john-smith" },
+    ]);
+  });
+
+  it("finds last-name prefix matches via rotated token keys", () => {
+    expect(searchAthletesInIndex("smith", athletes, keys)).toMatchObject([
+      { slug: "john-smith" },
+      { slug: "sarah-smith" },
+    ]);
+  });
+
+  it("finds last-name-first multi-token queries", () => {
+    expect(searchAthletesInIndex("smith jo", athletes, keys)).toMatchObject([
+      { slug: "john-smith" },
+    ]);
+  });
+
+  it("does not duplicate entries found through multiple search keys", () => {
+    const results = searchAthletesInIndex("john", athletes, keys);
+    expect(results.map((athlete) => athlete.slug)).toEqual(["john-smith"]);
+  });
+
+  it("keeps substring fallback for non-token infix queries", () => {
+    expect(searchAthletesInIndex("oldsmith", athletes, keys)).toMatchObject([
+      { slug: "alicia-goldsmith" },
+    ]);
+  });
+
+  it("returns empty for empty/whitespace query", () => {
+    expect(searchAthletesInIndex("", athletes, keys)).toEqual([]);
+    expect(searchAthletesInIndex("   ", athletes, keys)).toEqual([]);
+  });
+
+  it("respects the limit", () => {
+    expect(searchAthletesInIndex("s", athletes, keys, 1).length).toBe(1);
+  });
+});

--- a/app/src/lib/client-search-index.ts
+++ b/app/src/lib/client-search-index.ts
@@ -1,0 +1,89 @@
+import { AthleteSearchEntry } from "@/lib/types";
+import {
+  buildSearchKeys,
+  searchAthletesInIndex,
+  type IndexEntry,
+  type SearchKey,
+} from "@/lib/search-core";
+
+export interface ClientSearchIndex {
+  entries: IndexEntry[];
+  keys: SearchKey[];
+  loadStats: { downloadMs: number; parseMs: number; bytes: number };
+}
+
+const SEARCH_INDEX_URL = "/athlete-index.tsv.gz";
+
+export function parseIndexTsv(tsv: string): IndexEntry[] {
+  const lines = tsv.split("\n");
+  const entries: IndexEntry[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line) continue;
+    const t1 = line.indexOf("\t");
+    const t2 = line.indexOf("\t", t1 + 1);
+    const t3 = line.indexOf("\t", t2 + 1);
+    const t4 = line.indexOf("\t", t3 + 1);
+    const fullName = line.substring(t1 + 1, t2);
+    entries.push({
+      slug: line.substring(0, t1),
+      fullName,
+      fullNameLower: fullName.toLowerCase(),
+      country: line.substring(t2 + 1, t3),
+      countryISO: line.substring(t3 + 1, t4),
+      raceCount: +line.substring(t4 + 1),
+    });
+  }
+  return entries;
+}
+
+let loadPromise: Promise<ClientSearchIndex> | null = null;
+
+export function loadSearchIndex(): Promise<ClientSearchIndex> {
+  if (loadPromise) return loadPromise;
+  loadPromise = doLoadSearchIndex().catch((err) => {
+    // Keep the rejection cached so callers see the same error and we don't
+    // retry on every keystroke. The hook treats this as "stay on API path".
+    return Promise.reject(err);
+  });
+  return loadPromise;
+}
+
+async function doLoadSearchIndex(): Promise<ClientSearchIndex> {
+  if (typeof DecompressionStream === "undefined") {
+    throw new Error("DecompressionStream not supported");
+  }
+
+  const downloadStart = performance.now();
+  const response = await fetch(SEARCH_INDEX_URL);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to fetch search index: ${response.status}`);
+  }
+
+  const decompressed = response.body.pipeThrough(
+    new DecompressionStream("gzip"),
+  );
+  const tsv = await new Response(decompressed).text();
+  const downloadMs = performance.now() - downloadStart;
+  const bytes = tsv.length;
+
+  const parseStart = performance.now();
+  const entries = parseIndexTsv(tsv);
+  const keys = buildSearchKeys(entries);
+  const parseMs = performance.now() - parseStart;
+
+  return { entries, keys, loadStats: { downloadMs, parseMs, bytes } };
+}
+
+export function searchAthletesInClientIndex(
+  query: string,
+  index: ClientSearchIndex,
+  limit: number = 10,
+): AthleteSearchEntry[] {
+  return searchAthletesInIndex(query, index.entries, index.keys, limit);
+}
+
+// Test seam: reset memoization. Not exported through the package barrel.
+export function __resetForTests() {
+  loadPromise = null;
+}

--- a/app/src/lib/search-core.ts
+++ b/app/src/lib/search-core.ts
@@ -1,0 +1,139 @@
+import { AthleteSearchEntry } from "@/lib/types";
+
+export interface IndexEntry extends AthleteSearchEntry {
+  fullNameLower: string;
+}
+
+export interface SearchKey {
+  key: string;
+  index: number;
+}
+
+function toSearchResult(entry: IndexEntry): AthleteSearchEntry {
+  return {
+    slug: entry.slug,
+    fullName: entry.fullName,
+    country: entry.country,
+    countryISO: entry.countryISO,
+    raceCount: entry.raceCount,
+  };
+}
+
+function normalizeQuery(query: string): string {
+  return query.toLowerCase().trim().replace(/\s+/g, " ");
+}
+
+function getNameTokens(name: string): string[] {
+  return name.split(/[\s-]+/).filter(Boolean);
+}
+
+export function buildSearchKeys(index: IndexEntry[]): SearchKey[] {
+  const keys: SearchKey[] = [];
+  for (let i = 0; i < index.length; i++) {
+    const entry = index[i];
+    const tokens = getNameTokens(entry.fullNameLower);
+    const entryKeys = new Set<string>([entry.fullNameLower]);
+
+    for (let tokenIndex = 1; tokenIndex < tokens.length; tokenIndex++) {
+      entryKeys.add(
+        [...tokens.slice(tokenIndex), ...tokens.slice(0, tokenIndex)].join(" "),
+      );
+    }
+
+    for (const key of entryKeys) {
+      keys.push({ key, index: i });
+    }
+  }
+
+  return keys.sort((a, b) => {
+    const keyCompare = a.key.localeCompare(b.key);
+    return keyCompare || a.index - b.index;
+  });
+}
+
+function addMatch(
+  results: AthleteSearchEntry[],
+  seenSlugs: Set<string>,
+  entry: IndexEntry,
+  limit: number,
+): boolean {
+  if (seenSlugs.has(entry.slug)) return results.length >= limit;
+  seenSlugs.add(entry.slug);
+  results.push(toSearchResult(entry));
+  return results.length >= limit;
+}
+
+function findFirstKeyAtLeast(keys: SearchKey[], query: string): number {
+  let lo = 0;
+  let hi = keys.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    if (keys[mid].key < query) {
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return lo;
+}
+
+/**
+ * Search athletes with prefix matches prioritized over substring matches.
+ * Uses binary search over full names and rotated name-token keys, then keeps a
+ * linear substring scan as a compatibility fallback.
+ *
+ * Preconditions: `index` must be sorted by `fullNameLower`; `keys` must have
+ * been produced by `buildSearchKeys(index)` over the same index instance.
+ */
+export function searchAthletesInIndex(
+  query: string,
+  index: IndexEntry[],
+  keys: SearchKey[],
+  limit: number = 10,
+): AthleteSearchEntry[] {
+  const q = normalizeQuery(query);
+  if (!q) return [];
+
+  const results: AthleteSearchEntry[] = [];
+  const seenSlugs = new Set<string>();
+
+  // Pass 1: Binary search for prefix matches in sorted index
+  let lo = 0;
+  let hi = index.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    if (index[mid].fullNameLower < q) {
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  for (let i = lo; i < index.length && results.length < limit; i++) {
+    const entry = index[i];
+    if (!entry.fullNameLower.startsWith(q)) break;
+    addMatch(results, seenSlugs, entry, limit);
+  }
+
+  if (results.length >= limit) return results;
+
+  // Pass 2: Binary search rotated token keys, e.g. "smith john".
+  const keyStart = findFirstKeyAtLeast(keys, q);
+  for (let i = keyStart; i < keys.length && results.length < limit; i++) {
+    const searchKey = keys[i];
+    if (!searchKey.key.startsWith(q)) break;
+    addMatch(results, seenSlugs, index[searchKey.index], limit);
+  }
+
+  if (results.length > 0) return results;
+
+  // Pass 3: Linear scan for substring (non-prefix) matches.
+  for (const entry of index) {
+    if (results.length >= limit) break;
+    if (seenSlugs.has(entry.slug)) continue;
+    if (entry.fullNameLower.includes(q)) {
+      addMatch(results, seenSlugs, entry, limit);
+    }
+  }
+
+  return results;
+}

--- a/app/src/lib/search-index.ts
+++ b/app/src/lib/search-index.ts
@@ -2,15 +2,14 @@ import fs from "fs";
 import path from "path";
 import { gunzipSync } from "zlib";
 import { AthleteSearchEntry } from "@/lib/types";
+import {
+  buildSearchKeys,
+  searchAthletesInIndex as searchAthletesInIndexCore,
+  type IndexEntry,
+  type SearchKey,
+} from "@/lib/search-core";
 
-export interface IndexEntry extends AthleteSearchEntry {
-  fullNameLower: string;
-}
-
-interface SearchKey {
-  key: string;
-  index: number;
-}
+export type { IndexEntry, SearchKey } from "@/lib/search-core";
 
 let cachedIndex: IndexEntry[] | null = null;
 let cachedSearchKeys: SearchKey[] | null = null;
@@ -43,53 +42,10 @@ export function getSearchIndex(): IndexEntry[] {
         raceCount: +line.substring(t4 + 1),
       };
     }
-    // Index is pre-sorted by fullNameLower at build time
     cachedIndex = entries.filter(Boolean);
     cachedSearchKeys = buildSearchKeys(cachedIndex);
   }
   return cachedIndex;
-}
-
-function toSearchResult(entry: IndexEntry): AthleteSearchEntry {
-  return {
-    slug: entry.slug,
-    fullName: entry.fullName,
-    country: entry.country,
-    countryISO: entry.countryISO,
-    raceCount: entry.raceCount,
-  };
-}
-
-function normalizeQuery(query: string): string {
-  return query.toLowerCase().trim().replace(/\s+/g, " ");
-}
-
-function getNameTokens(name: string): string[] {
-  return name.split(/[\s-]+/).filter(Boolean);
-}
-
-function buildSearchKeys(index: IndexEntry[]): SearchKey[] {
-  const keys: SearchKey[] = [];
-  for (let i = 0; i < index.length; i++) {
-    const entry = index[i];
-    const tokens = getNameTokens(entry.fullNameLower);
-    const entryKeys = new Set<string>([entry.fullNameLower]);
-
-    for (let tokenIndex = 1; tokenIndex < tokens.length; tokenIndex++) {
-      entryKeys.add(
-        [...tokens.slice(tokenIndex), ...tokens.slice(0, tokenIndex)].join(" "),
-      );
-    }
-
-    for (const key of entryKeys) {
-      keys.push({ key, index: i });
-    }
-  }
-
-  return keys.sort((a, b) => {
-    const keyCompare = a.key.localeCompare(b.key);
-    return keyCompare || a.index - b.index;
-  });
 }
 
 function getSearchKeys(): SearchKey[] {
@@ -99,89 +55,13 @@ function getSearchKeys(): SearchKey[] {
   return cachedSearchKeys;
 }
 
-function addMatch(
-  results: AthleteSearchEntry[],
-  seenSlugs: Set<string>,
-  entry: IndexEntry,
-  limit: number,
-): boolean {
-  if (seenSlugs.has(entry.slug)) return results.length >= limit;
-  seenSlugs.add(entry.slug);
-  results.push(toSearchResult(entry));
-  return results.length >= limit;
-}
-
-function findFirstKeyAtLeast(keys: SearchKey[], query: string): number {
-  let lo = 0;
-  let hi = keys.length - 1;
-  while (lo <= hi) {
-    const mid = (lo + hi) >>> 1;
-    if (keys[mid].key < query) {
-      lo = mid + 1;
-    } else {
-      hi = mid - 1;
-    }
-  }
-  return lo;
-}
-
-/**
- * Search athletes with prefix matches prioritized over substring matches.
- * Uses binary search over full names and rotated name-token keys, then keeps a
- * linear substring scan as a compatibility fallback.
- */
 export function searchAthletesInIndex(
   query: string,
   index: IndexEntry[],
   limit: number = 10,
 ): AthleteSearchEntry[] {
-  const q = normalizeQuery(query);
-  if (!q) return [];
-
-  const results: AthleteSearchEntry[] = [];
-  const seenSlugs = new Set<string>();
-
-  // Pass 1: Binary search for prefix matches in sorted index
-  let lo = 0;
-  let hi = index.length - 1;
-  while (lo <= hi) {
-    const mid = (lo + hi) >>> 1;
-    if (index[mid].fullNameLower < q) {
-      lo = mid + 1;
-    } else {
-      hi = mid - 1;
-    }
-  }
-  // lo is now the first entry >= q; scan forward for prefix matches
-  for (let i = lo; i < index.length && results.length < limit; i++) {
-    const entry = index[i];
-    if (!entry.fullNameLower.startsWith(q)) break;
-    addMatch(results, seenSlugs, entry, limit);
-  }
-
-  if (results.length >= limit) return results;
-
-  // Pass 2: Binary search rotated token keys, e.g. "smith john".
   const keys = index === cachedIndex ? getSearchKeys() : buildSearchKeys(index);
-  const keyStart = findFirstKeyAtLeast(keys, q);
-  for (let i = keyStart; i < keys.length && results.length < limit; i++) {
-    const searchKey = keys[i];
-    if (!searchKey.key.startsWith(q)) break;
-    addMatch(results, seenSlugs, index[searchKey.index], limit);
-  }
-
-  if (results.length > 0) return results;
-
-  // Pass 3: Linear scan for substring (non-prefix) matches.
-  for (const entry of index) {
-    if (results.length >= limit) break;
-    if (seenSlugs.has(entry.slug)) continue;
-    if (entry.fullNameLower.includes(q)) {
-      addMatch(results, seenSlugs, entry, limit);
-    }
-  }
-
-  return results;
+  return searchAthletesInIndexCore(query, index, keys, limit);
 }
 
 export function searchAthletes(

--- a/scripts/copy-search-index.js
+++ b/scripts/copy-search-index.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+/**
+ * Mirrors data/athlete-index.tsv.gz into app/public/ so Next.js serves it
+ * as a static asset to the browser for client-side search. Run from npm
+ * predev and from the build chain — the source file is committed to git,
+ * so this is a cheap deterministic copy with no parsing.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const src = path.join(__dirname, "..", "data", "athlete-index.tsv.gz");
+const dst = path.join(__dirname, "..", "app", "public", "athlete-index.tsv.gz");
+
+if (!fs.existsSync(src)) {
+  console.error(`Missing ${src}. Run scripts/build-search-index.js first.`);
+  process.exit(1);
+}
+
+fs.mkdirSync(path.dirname(dst), { recursive: true });
+fs.copyFileSync(src, dst);
+
+const bytes = fs.statSync(dst).size;
+console.log(`Copied search index → ${path.relative(process.cwd(), dst)} (${bytes} bytes)`);


### PR DESCRIPTION
## Summary
- Move homepage athlete search from a server `/api/search` round-trip per keystroke to a client-side index served as a static asset.
- Browser fetches `/athlete-index.tsv.gz` once per session (CDN-cached with `stale-while-revalidate=604800`), decompresses with `DecompressionStream`, then runs the same prefix / rotated-token / substring search locally — `~56µs` per query on the full 808K-athlete index.
- API stays as the fallback while the index is in flight (typically the first 1–2 s of a fresh visit on broadband) and for browsers without `DecompressionStream`.
- New Vercel Analytics events `search_latency` (`source: "client" | "api"`), `search_index_load`, and `search_index_load_error` let us verify the win in production.

## Test plan
- [ ] Open the homepage, focus search, type a name. First keystroke or two may hit `/api/search` (visible in Network); subsequent keystrokes show no further network requests.
- [ ] Hard refresh — index served from browser HTTP cache, every keystroke is local from the start.
- [ ] DevTools → throttle to "Slow 3G" → hard refresh → type immediately. `/api/search` fallback populates results while the index downloads in the background.
- [ ] Cmd-K command palette on a non-home page (e.g. `/races`) still works.
- [ ] `cd app && npm run build` succeeds with the new copy step in the build chain.
- [ ] `cd app && npm run test` — 35/35 passing, `npx tsc --noEmit` clean, `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)