### PR TITLE
ci: request review from rootulp on auto-scrape PRs

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -76,7 +76,8 @@ jobs:
           gh pr create \
             --head "$BRANCH" \
             --title "feat: add new race results" \
-            --body-file /tmp/pr-body.md
+            --body-file /tmp/pr-body.md \
+            --reviewer rootulp
 
           # Request auto-merge so the PR squash-merges once CI passes,
           # instead of piling up as a stale daily backlog.


### PR DESCRIPTION
## Summary

Add `--reviewer rootulp` to the `gh pr create` call in the daily scrape workflow (`.github/workflows/scrape.yml`) so the repo owner is requested as a reviewer on each auto-generated race-results PR, triggering a GitHub notification.

## Notes

- The existing `pull-requests: write` permission already covers requesting reviewers — no permission change needed.
- This works because the PR author is `github-actions[bot]`; GitHub rejects requesting a review from the PR author.
- Auto-merge is unaffected — PRs still squash-merge once CI passes. The review request is purely for notification/visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to automatically assign a reviewer to auto-generated pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->