### PR TITLE
perf: keep the data corpus out of thin function bundles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@ Data is collected from https://www.ironman.com/races/im703-new-york/results. Ins
 
 ## Key File Paths
 
-- `app/src/lib/data.ts` — Server-side data access (reads CSVs, computes histograms, athlete deduplication & profiles)
+- `app/src/lib/data.ts` — Corpus-reading data access (CSVs, histograms, athlete index). Any route importing it gets ~190MB traced into its function bundle — routes that only need the race manifest must import `races.ts` instead (enforced by `import-graph.test.ts`)
+- `app/src/lib/races.ts` — Race-manifest access (`data/races.json` only); safe for instrumentation and thin routes
 - `app/src/lib/types.ts` — TypeScript interfaces (`AthleteSearchEntry`, `AthleteProfile`, `AthleteRaceEntry`, etc.)
 - `app/src/lib/colors.ts` — Canonical discipline color constants (swim, bike, run, overall, T1, T2)
 - `app/src/lib/flags.ts` — Country ISO to flag emoji mapping

--- a/app/src/app/races/page.tsx
+++ b/app/src/app/races/page.tsx
@@ -1,4 +1,4 @@
-import { getRaces } from "@/lib/data";
+import { getRaces } from "@/lib/races";
 import RaceList from "./race-list";
 
 export const revalidate = false;

--- a/app/src/app/sitemap.ts
+++ b/app/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { getRaces } from "@/lib/data";
+import { getRaces } from "@/lib/races";
 
 const SITE_URL = "https://tritimes.org";
 

--- a/app/src/instrumentation.ts
+++ b/app/src/instrumentation.ts
@@ -1,6 +1,10 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
-    const { getRaces } = await import("@/lib/data");
+    // Warm the race-manifest cache before the first request. Import only
+    // @/lib/races here: instrumentation is bundled into EVERY Node function,
+    // so importing @/lib/data would copy the ~190MB data corpus into every
+    // function's traced bundle and add seconds of cold start (#216).
+    const { getRaces } = await import("@/lib/races");
     getRaces();
   }
 }

--- a/app/src/lib/__tests__/import-graph.test.ts
+++ b/app/src/lib/__tests__/import-graph.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Traced-bundle hygiene: `@/lib/data` reads the whole data corpus
+ * (data/*.csv.gz, data/histograms/*, athlete-index.tsv.gz) with fs globs, so
+ * Next's output file tracing copies ~190MB into the bundle of every function
+ * whose import graph reaches it. Functions that ship that corpus cold-boot in
+ * ~4.5s on Vercel (issue #216).
+ *
+ * `instrumentation.ts` is bundled into EVERY Node function, so it must never
+ * reach data.ts. The other entries are routes that only need races.json (or
+ * nothing) and must stay thin. This regression has happened twice — #97 added
+ * the import for index warming and #214 removed the index but left getRaces.
+ */
+
+const SRC_ROOT = path.resolve(__dirname, "..", "..");
+
+// Entry files whose transitive import graph must NOT include lib/data.ts.
+const THIN_ENTRYPOINTS = [
+  "instrumentation.ts", // bundled into every Node function
+  "app/sitemap.ts", // needs races.json only
+  "app/races/page.tsx", // needs races.json only
+  "app/api/search/route.ts", // search shards are self-fetched over HTTP
+  "app/athlete/[slug]/page.tsx", // edge runtime: must stay fs-free entirely
+];
+
+const FORBIDDEN = path.join(SRC_ROOT, "lib", "data.ts");
+
+// Matches static imports/re-exports and dynamic import() specifiers.
+const IMPORT_RE = /(?:import|export)\s[^"']*?from\s*["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)/g;
+
+function resolveSpecifier(spec: string, fromDir: string): string | null {
+  let base: string;
+  if (spec.startsWith("@/")) {
+    base = path.join(SRC_ROOT, spec.slice(2));
+  } else if (spec.startsWith(".")) {
+    base = path.resolve(fromDir, spec);
+  } else {
+    return null; // bare specifier (node_modules / node builtins)
+  }
+  for (const candidate of [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    path.join(base, "index.ts"),
+    path.join(base, "index.tsx"),
+  ]) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function transitiveImports(entry: string): Set<string> {
+  const seen = new Set<string>();
+  const queue = [entry];
+  while (queue.length > 0) {
+    const file = queue.pop()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+    const source = fs.readFileSync(file, "utf-8");
+    for (const match of source.matchAll(IMPORT_RE)) {
+      const resolved = resolveSpecifier(match[1] ?? match[2], path.dirname(file));
+      if (resolved && !seen.has(resolved)) queue.push(resolved);
+    }
+  }
+  return seen;
+}
+
+describe("function trace hygiene", () => {
+  it.each(THIN_ENTRYPOINTS)("%s does not (transitively) import lib/data.ts", (rel) => {
+    const entry = path.join(SRC_ROOT, rel);
+    expect(fs.existsSync(entry), `${rel} should exist`).toBe(true);
+    const graph = transitiveImports(entry);
+    expect(
+      graph.has(FORBIDDEN),
+      `${rel} reaches lib/data.ts — its fs globs pull the ~190MB data corpus ` +
+        `into this function's traced bundle (issue #216). Import @/lib/races ` +
+        `(or another thin module) instead.`,
+    ).toBe(false);
+  });
+
+  // Sanity check that the walker actually follows imports: the result page
+  // legitimately reads the corpus through lib/data.ts.
+  it("race result page DOES reach lib/data.ts (walker sanity check)", () => {
+    const graph = transitiveImports(
+      path.join(SRC_ROOT, "app/race/[slug]/result/[id]/page.tsx"),
+    );
+    expect(graph.has(FORBIDDEN)).toBe(true);
+  });
+});

--- a/app/src/lib/data.ts
+++ b/app/src/lib/data.ts
@@ -1,35 +1,18 @@
 import fs from "fs";
 import path from "path";
 import { gunzipSync } from "zlib";
-import { AggregateStats, AthleteResult, AthleteSearchEntry, AgeGroupBreakdown, CourseStats, DisciplineStats, GenderBreakdown, HistogramBin, HistogramData, LeaderboardEntry, RaceHistogramData, RaceInfo, RaceStats } from "./types";
+import { AggregateStats, AthleteResult, AthleteSearchEntry, AgeGroupBreakdown, CourseStats, DisciplineStats, GenderBreakdown, HistogramBin, HistogramData, LeaderboardEntry, RaceHistogramData, RaceStats } from "./types";
+import { getRaces } from "./races";
 
-interface RaceManifestEntry {
-  slug: string;
-  name: string;
-  date: string;
-  location: string;
-  eventId: string;
-  finishers: number;
-}
+// Corpus-reading data access: everything here may reference data/*.csv.gz,
+// data/histograms/* and data/athlete-index.tsv.gz, so any function whose
+// import graph reaches this module gets the whole ~190MB corpus copied into
+// its traced bundle. Routes that only need the race manifest must import
+// @/lib/races instead (enforced by import-graph.test.ts; see #216).
 
-function loadRaces(): RaceInfo[] {
-  const manifestPath = path.join(process.cwd(), "..", "data", "races.json");
-  const raw = fs.readFileSync(manifestPath, "utf-8");
-  const entries: RaceManifestEntry[] = JSON.parse(raw);
-  return entries.map((e) => ({
-    slug: e.slug,
-    name: e.name,
-    date: e.date,
-    location: e.location,
-    finishers: e.finishers || 0,
-  }));
-}
-
-let racesCache: RaceInfo[] | null = null;
-function getRacesInternal(): RaceInfo[] {
-  if (!racesCache) racesCache = loadRaces();
-  return racesCache;
-}
+// Manifest accessors are re-exported so corpus-reading routes (race/result
+// pages) can keep importing everything from @/lib/data.
+export { getRaces, getRaceBySlug, getGlobalStats } from "./races";
 
 const cache = new Map<string, AthleteResult[]>();
 
@@ -153,14 +136,6 @@ function parseCSV(raceSlug: string): AthleteResult[] {
   return results;
 }
 
-export function getRaces(): RaceInfo[] {
-  return getRacesInternal();
-}
-
-export function getRaceBySlug(slug: string): RaceInfo | undefined {
-  return getRacesInternal().find((r) => r.slug === slug);
-}
-
 export function getAllResults(raceSlug: string): AthleteResult[] {
   return parseCSV(raceSlug);
 }
@@ -217,16 +192,6 @@ export function getCourseStats(): CourseStats[] {
   return courseStatsCache!;
 }
 
-export function getGlobalStats(): { raceCount: number; totalResults: number } {
-  const manifestPath = path.join(process.cwd(), "..", "data", "races.json");
-  const raw = fs.readFileSync(manifestPath, "utf-8");
-  const entries: RaceManifestEntry[] = JSON.parse(raw);
-  return {
-    raceCount: entries.length,
-    totalResults: entries.reduce((sum, e) => sum + (e.finishers || 0), 0),
-  };
-}
-
 let aggregateStatsCache: AggregateStats | null = null;
 
 function loadAggregateStats(): AggregateStats {
@@ -262,7 +227,7 @@ export interface StatsPageData {
 }
 
 export function getStatsPageData(): StatsPageData {
-  const races = getRacesInternal();
+  const races = getRaces();
   const sorted = [...races].sort((a, b) => a.date.localeCompare(b.date));
   const earliest = sorted[0];
   const mostRecent = sorted[sorted.length - 1];

--- a/app/src/lib/races.ts
+++ b/app/src/lib/races.ts
@@ -1,0 +1,55 @@
+import fs from "fs";
+import path from "path";
+import { RaceInfo } from "./types";
+
+// Race-manifest access (data/races.json only). This module is imported by
+// instrumentation.ts — which is bundled into EVERY Node function — and by
+// routes that need nothing else (sitemap, /races). It must never read other
+// files under data/: each fs path referenced here is copied into the traced
+// bundle of every importing function (see import-graph.test.ts and #216).
+// Corpus-reading code (CSVs, histograms, athlete index) lives in data.ts.
+
+interface RaceManifestEntry {
+  slug: string;
+  name: string;
+  date: string;
+  location: string;
+  eventId: string;
+  finishers: number;
+}
+
+function manifestPath(): string {
+  return path.join(process.cwd(), "..", "data", "races.json");
+}
+
+function loadRaces(): RaceInfo[] {
+  const raw = fs.readFileSync(manifestPath(), "utf-8");
+  const entries: RaceManifestEntry[] = JSON.parse(raw);
+  return entries.map((e) => ({
+    slug: e.slug,
+    name: e.name,
+    date: e.date,
+    location: e.location,
+    finishers: e.finishers || 0,
+  }));
+}
+
+let racesCache: RaceInfo[] | null = null;
+
+export function getRaces(): RaceInfo[] {
+  if (!racesCache) racesCache = loadRaces();
+  return racesCache;
+}
+
+export function getRaceBySlug(slug: string): RaceInfo | undefined {
+  return getRaces().find((r) => r.slug === slug);
+}
+
+export function getGlobalStats(): { raceCount: number; totalResults: number } {
+  const raw = fs.readFileSync(manifestPath(), "utf-8");
+  const entries: RaceManifestEntry[] = JSON.parse(raw);
+  return {
+    raceCount: entries.length,
+    totalResults: entries.reduce((sum, e) => sum + (e.finishers || 0), 0),
+  };
+}


### PR DESCRIPTION
Closes #216 (GitHub issue; no Linear issue exists for this work)

## Problem

After #210/#211/#213/#214, no journey-path route parses a big index anymore, but every Node function still cold-booted in ~4.5s (#216: first `/api/search` invocation ~4.7s, of which ~4.4s is pure cold start).

**Root cause:** `instrumentation.ts` — which is bundled into **every** Node function — imported `@/lib/data` to warm the race manifest. `data.ts` reads `data/*.csv.gz`, `data/histograms/*.json.gz` and `data/athlete-index.tsv.gz` with dynamic `fs` paths, so Next's output file tracing copied the whole ~191MB corpus into every function bundle, even routes that never touch it (`/api/search`'s own trace is 1.1MB).

## Fix

- New `app/src/lib/races.ts`: race-manifest access only (`data/races.json`, a few KB). `data.ts` re-exports its accessors so corpus-reading routes are unchanged.
- `instrumentation.ts`, `sitemap.ts`, and `/races` now import `@/lib/races`, keeping `data.ts` (and its fs globs) out of their import graphs.
- New `import-graph.test.ts` guard: asserts `lib/data.ts` is unreachable from thin entrypoints (instrumentation, sitemap, `/races`, `/api/search`, edge athlete page). This regression shipped twice before (#97, #214), so it gets a test.

## Measured traced-bundle sizes (`.nft.json`, local `next build`)

| Function | Before | After |
|---|---|---|
| `instrumentation.js` (ships with every function) | 191.6MB | **0.3MB** |
| `/api/search` (route + instrumentation) | ~192MB | **~1.4MB** |
| `/sitemap.xml` | 192.7MB | **1.4MB** |
| `/races` | 192.8MB | **1.5MB** |
| race / result / og-image / stats | ~193MB | ~193MB (these genuinely read the corpus at request time — possible follow-up: self-fetch CSVs as static assets) |

`data/races.json` remains correctly traced into instrumentation/sitemap/races (verified in `.nft.json`).

## Verification

- `npx vitest run` — 91/91 pass (new guard test red before the fix, green after)
- `npm run lint` — clean
- `next build` + `next start` smoke test: `/`, `/races`, `/sitemap.xml`, `/api/search?q=smith`, `/stats`, `/courses`, `/race/im-hamburg-2026`, result page, athlete page, og-image all 200
- Cold-path journey gate against the fresh preview (first-ever traffic): **PASS — 1611ms total vs 2500ms budget** (homepage 470ms, search 394ms, athlete page 747ms). Also verifies #215's search leg: 394ms cold vs 8034ms before #214.
- First-ever `/api/search` invocation on the fresh preview: **774ms** (was ~4.7s in #216); warm with new shard 401ms, cached shard 76ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined how race information is accessed across the application by consolidating data patterns, eliminating unnecessary dependencies, and improving page load performance.

* **Tests**
  * Added automated validation to ensure critical application routes remain performant and prevent unintended inclusion of heavy dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
