### PR TITLE
fix: prevent content bleed-through on translucent sticky header

### DIFF
--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -48,7 +48,7 @@ export default function Header() {
   ];
 
   return (
-    <header className="sticky top-0 z-50 bg-gray-900/95 border-b border-gray-800">
+    <header className="sticky top-0 z-50 bg-gray-900/95 backdrop-blur-sm border-b border-gray-800">
       <div className="max-w-6xl mx-auto px-4 h-14 flex items-center justify-between">
         <Link href="/" className="text-lg font-bold text-white hover:text-gray-300 transition-colors">
           TriTimes


### PR DESCRIPTION
Closes #217

## Summary

While scrolling, bright page text behind the sticky header (`bg-gray-900/95`, no backdrop blur) remained legible and overlapped the TriTimes logo and nav links. This keeps the 95% translucency but adds `backdrop-blur-sm` to `app/src/components/Header.tsx`, so content passing under the header is blurred rather than readable.

Styling-only, one-line change; mobile menu behavior is untouched (covered by a separate PR).

## Testing

- `npx vitest run` — 85 tests passed (9 files)
- `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Header styling with a subtle backdrop blur effect for improved visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->