### PR TITLE
feat: add branded 404 page with navigation and search

### DIFF
--- a/app/src/app/not-found.tsx
+++ b/app/src/app/not-found.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import GlobalSearchBar from "@/components/GlobalSearchBar";
+
+export const metadata = {
+  title: "Page not found | TriTimes",
+};
+
+export default function NotFound() {
+  return (
+    <main className="flex-1 max-w-6xl w-full mx-auto px-4 py-8">
+      <div className="flex flex-col items-center text-center pt-16 pb-20">
+        <p className="text-sm font-semibold tracking-widest text-blue-400 uppercase mb-3">
+          404
+        </p>
+        <h1 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+          Page not found
+        </h1>
+        <p className="text-gray-400 max-w-md mb-10 leading-relaxed">
+          This page doesn&apos;t exist — the link may be stale, or the race or
+          result may have moved. Try searching for an athlete below.
+        </p>
+
+        <div className="w-full max-w-lg mb-10">
+          <GlobalSearchBar />
+        </div>
+
+        <div className="flex flex-wrap items-center justify-center gap-4">
+          <Link
+            href="/"
+            className="px-5 py-2.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white font-semibold transition-colors"
+          >
+            Go home
+          </Link>
+          <Link
+            href="/races"
+            className="px-5 py-2.5 rounded-lg border border-gray-700/80 bg-gray-900 hover:border-gray-500 text-white font-semibold transition-colors"
+          >
+            Browse races
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Closes #222

## Summary

Bad URLs (e.g. `/race/nonexistent-race-2099`, stale result ids like `/race/im-hamburg-2026/result/99999`) rendered the stock Next.js "404 | This page could not be found." page — no branding, no link home, no search.

This adds `app/src/app/not-found.tsx` (App Router convention) with TriTimes dark-theme styling:

- A "404 / Page not found" heading matching the site's typography (same `max-w-6xl` container and `text-3xl font-bold text-white` heading style as the Stats page)
- A short friendly message explaining the link may be stale
- The global athlete search (`GlobalSearchBar`, already a client component, drops in cleanly) so dead links still give users a path forward
- Prominent links to `/` (Go home) and `/races` (Browse races)

No other changes were needed: the race, result, and athlete pages already call `notFound()` from `next/navigation`, so the new page renders for all of them. The root layout already wraps `not-found.tsx` with the site header and footer.

## Test notes

- `npx vitest run` — 9 test files, 85 tests, all passing
- `npm run lint` — clean
- Markup/styling change only, so no new tests were added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a custom 404 error page that displays when users navigate to non-existent pages. The page includes a helpful message, explanatory text, an integrated search bar for quick navigation, and convenient links to return home or browse available races.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->