### PR TITLE
fix: improve mobile nav menu behavior and add Stats link

### DIFF
--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useSyncExternalStore } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -41,14 +41,53 @@ export default function Header() {
   const [menuOpen, setMenuOpen] = useState(false);
   const isMac = useIsMac();
   const pathname = usePathname();
+  const headerRef = useRef<HTMLElement>(null);
 
   const links = [
     { href: "/races", label: "Races" },
     { href: "/courses", label: "Courses" },
+    { href: "/stats", label: "Stats" },
   ];
 
+  // Close the mobile menu on route change (state adjustment during render).
+  const [prevPathname, setPrevPathname] = useState(pathname);
+  if (prevPathname !== pathname) {
+    setPrevPathname(pathname);
+    setMenuOpen(false);
+  }
+
+  // While the mobile menu is open: close on Escape or outside tap, and lock body scroll.
+  useEffect(() => {
+    if (!menuOpen) return;
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setMenuOpen(false);
+    }
+
+    function onPointerDown(event: PointerEvent) {
+      if (
+        headerRef.current &&
+        event.target instanceof Node &&
+        !headerRef.current.contains(event.target)
+      ) {
+        setMenuOpen(false);
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("pointerdown", onPointerDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [menuOpen]);
+
   return (
-    <header className="sticky top-0 z-50 bg-gray-900/95 backdrop-blur-sm border-b border-gray-800">
+    <header ref={headerRef} className="sticky top-0 z-50 bg-gray-900/95 backdrop-blur-sm border-b border-gray-800">
       <div className="max-w-6xl mx-auto px-4 h-14 flex items-center justify-between">
         <Link href="/" className="text-lg font-bold text-white hover:text-gray-300 transition-colors">
           TriTimes


### PR DESCRIPTION
Closes #223

## Summary

Fixes the three mobile hamburger-menu issues from #223 in `app/src/components/Header.tsx`:

- **Escape closes the menu** — a `keydown` listener is attached while the menu is open.
- **Body scroll lock** — `document.body.style.overflow = "hidden"` while open, with the previous value restored on close/unmount.
- **Stats link added** — `/stats` is now in the shared `links` array, so both the desktop nav and the mobile menu agree with the footer. (Feedback is an external Google Form, so it stays footer-only.)

Also:

- **Close on route change** — the menu closes whenever `pathname` changes (render-time state adjustment, per the `react-hooks/set-state-in-effect` lint rule), so navigating via the logo or any other link never leaves it open.
- **Close on outside tap** — a `pointerdown` listener closes the menu when tapping outside the header.

The header's background classes are untouched to avoid conflicts with the in-flight header-styling PR.

## Test notes

- No DOM/component testing infra exists (vitest tests are pure-logic `.ts`, no jsdom/testing-library), so the event wiring has no new unit tests; the existing suite stays green.
- `npx vitest run`: 85 tests passed (9 files).
- `npm run lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Stats" route to the navigation menu
  * Mobile menu now automatically closes when navigating to a different page
  * Mobile menu closes on Escape key or when clicking outside the header
  * Page scrolling is disabled while the mobile menu is open (scroll lock with cleanup)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->