### PR TITLE
feat: link athlete name on result page to athlete profile

### DIFF
--- a/app/src/app/race/[slug]/result/[id]/page.tsx
+++ b/app/src/app/race/[slug]/result/[id]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { getRaceBySlug, getAthleteById, getGenderCount, getAgeGroupCount, getAllResults } from "@/lib/data";
 import ResultCard from "@/components/ResultCard";
 import { getCountryFlagISO } from "@/lib/flags";
+import { slugifyAthlete } from "@/lib/athlete-slug";
 import HistogramSection, { HistogramSectionFallback } from "@/components/HistogramSection";
 import ShareDialog from "@/components/ShareDialog";
 
@@ -38,6 +39,8 @@ export default async function ResultPage({ params }: PageProps) {
   const ageGroupPct = Math.max(1, Math.round((athlete.ageGroupRank / ageGroupTotal) * 100));
 
   const flag = getCountryFlagISO(athlete.countryISO);
+  // Falls back to a plain heading when country/gender is missing.
+  const athleteSlug = slugifyAthlete(athlete.fullName, athlete.countryISO, athlete.gender);
   const location = [athlete.city, athlete.state, athlete.country].filter(Boolean).join(", ");
 
   const shareUrl = `https://tritimes.org/race/${slug}/result/${id}`;
@@ -50,7 +53,13 @@ export default async function ResultPage({ params }: PageProps) {
         <div className="min-w-0">
           <h1 className="text-3xl font-bold text-white">
             {flag && <span className="mr-2">{flag}</span>}
-            {athlete.fullName}
+            {athleteSlug ? (
+              <Link href={`/athlete/${athleteSlug}`} className="hover:text-blue-400 transition-colors">
+                {athlete.fullName}
+              </Link>
+            ) : (
+              athlete.fullName
+            )}
           </h1>
           <p className="text-gray-400 mt-1">
             <Link href={`/race/${slug}`} className="text-blue-400 hover:underline">{race.name}</Link> &middot; Bib #{athlete.bib} &middot; {athlete.ageGroup} &middot; {location}

--- a/app/src/lib/__tests__/athlete-slug.test.ts
+++ b/app/src/lib/__tests__/athlete-slug.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { slugifyAthlete } from "@/lib/athlete-slug";
+import { createRequire } from "module";
+const nodeRequire = createRequire(import.meta.url);
+const buildShards = nodeRequire("../../../../scripts/build-athlete-shards.js");
+
+describe("slugifyAthlete", () => {
+  it("builds slugs as name--country-genderInitial", () => {
+    expect(slugifyAthlete("Smith Anderson", "US", "Male")).toBe("smith-anderson--us-m");
+    expect(slugifyAthlete("Ann Lee", "US", "Female")).toBe("ann-lee--us-f");
+  });
+
+  it("strips diacritics and collapses non-alphanumerics", () => {
+    expect(slugifyAthlete("José Núñez-Día", "MX", "Male")).toBe("jose-nunez-dia--mx-m");
+    expect(slugifyAthlete("  O'Brien, Jr. ", "IE", "Male")).toBe("o-brien-jr--ie-m");
+  });
+
+  it("matches the build script's slugifyAthlete (parity anchor)", () => {
+    const cases: Array<[string, string, string]> = [
+      ["Smith Anderson", "US", "Male"],
+      ["Garcia Araceli del Rocío", "MX", "Female"],
+      ["Martin Kodewitz", "DE", "Male"],
+    ];
+    for (const [name, iso, gender] of cases) {
+      expect(slugifyAthlete(name, iso, gender)).toBe(buildShards.slugifyAthlete(name, iso, gender));
+    }
+  });
+
+  it("returns null when any input needed for the slug is missing", () => {
+    expect(slugifyAthlete("", "US", "Male")).toBeNull();
+    expect(slugifyAthlete("Ann Lee", "", "Female")).toBeNull();
+    expect(slugifyAthlete("Ann Lee", "US", "")).toBeNull();
+    // Name made only of punctuation slugifies to an empty base.
+    expect(slugifyAthlete("---", "US", "Male")).toBeNull();
+  });
+});

--- a/app/src/lib/athlete-slug.ts
+++ b/app/src/lib/athlete-slug.ts
@@ -1,0 +1,26 @@
+// Canonical athlete profile slug (e.g. "smith-anderson--us-m").
+//
+// Must stay in lockstep with slugifyAthlete in scripts/build-search-index.js
+// and scripts/build-athlete-shards.js — those scripts generate the athlete
+// index and profile shards that /athlete/[slug] is served from. Parity is
+// enforced by app/src/lib/__tests__/athlete-slug.test.ts.
+//
+// Returns null when any required field is missing so callers can fall back
+// to rendering a non-linked name.
+export function slugifyAthlete(
+  fullName: string,
+  countryISO: string,
+  gender: string,
+): string | null {
+  if (!fullName || !countryISO || !gender) return null;
+  const base = fullName
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  if (!base) return null;
+  const country = countryISO.toLowerCase();
+  const g = gender.toLowerCase().charAt(0);
+  return `${base}--${country}-${g}`;
+}


### PR DESCRIPTION
Closes #221

## Summary

- The athlete name heading on `/race/[slug]/result/[id]` now links to the athlete's profile page (`/athlete/[slug]`), so users landing on a shared result can reach the athlete's cross-race history. The reverse direction (profile → result) already worked.
- Adds `app/src/lib/athlete-slug.ts`: a TypeScript copy of the canonical `slugifyAthlete` recipe used by `scripts/build-search-index.js` and `scripts/build-athlete-shards.js` (lowercased NFD-normalized name + `--` + country ISO + gender initial). A parity test asserts it matches the build script's exported `slugifyAthlete`, so any drift between app and index/shard generation is caught by CI.
- Graceful fallback: if name, country ISO, or gender is missing (or the name slugifies to empty), `slugifyAthlete` returns `null` and the page renders the plain non-linked heading as before.
- Styling matches existing heading links (`hover:text-blue-400 transition-colors`, as used on the race page's Top Finishers and stats page).

## Test notes

- Red/green TDD: added `app/src/lib/__tests__/athlete-slug.test.ts` (slug shape, diacritics, build-script parity, missing-field fallback) before implementing the helper.
- `npx vitest run`: 10 files, 89 tests passed.
- `npm run lint` (eslint): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Athlete names on race result pages are now clickable links, allowing direct navigation to individual athlete profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->