### PR TITLE
feat: add text filter to races page

### DIFF
--- a/app/src/app/races/race-list.tsx
+++ b/app/src/app/races/race-list.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import type { RaceInfo } from "@/lib/types";
 import { getCountryFlag } from "@/lib/flags";
+import { filterRaces } from "@/lib/race-filter";
 
 function formatDate(iso: string): string {
   const date = new Date(iso + "T00:00:00");
@@ -29,15 +30,11 @@ function getYear(date: string): string {
 export default function RaceList({ races }: { races: RaceInfo[] }) {
   const [distance, setDistance] = useState<string>("All");
   const [year, setYear] = useState<string>("All");
+  const [query, setQuery] = useState<string>("");
 
   const years = [...new Set(races.map((r) => getYear(r.date)))].sort().reverse();
 
-  const filtered = races.filter((race) => {
-    if (distance === "70.3" && !race.slug.startsWith("im703-")) return false;
-    if (distance === "140.6" && race.slug.startsWith("im703-")) return false;
-    if (year !== "All" && getYear(race.date) !== year) return false;
-    return true;
-  });
+  const filtered = filterRaces(races, { distance, year, query });
 
   const btnClass = (active: boolean) =>
     active
@@ -71,11 +68,45 @@ export default function RaceList({ races }: { races: RaceInfo[] }) {
             ))}
           </select>
         </div>
+
+        <div className="flex items-center gap-2">
+          <label
+            htmlFor="race-search"
+            className="text-xs font-medium text-gray-500 uppercase tracking-wider mr-1"
+          >
+            Search
+          </label>
+          <input
+            id="race-search"
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Name or location"
+            autoComplete="off"
+            className="px-4 py-2 rounded-full text-sm font-medium bg-white/10 text-white ring-1 ring-white/20 border-none placeholder:text-gray-500 focus:outline-none focus:ring-white/40 w-56"
+          />
+        </div>
       </div>
 
       <p className="text-sm text-gray-500 mb-4">
         Showing {filtered.length} of {races.length} races
       </p>
+
+      {filtered.length === 0 && (
+        <div className="py-12 text-center">
+          <p className="text-gray-400">No races match your filters.</p>
+          <button
+            onClick={() => {
+              setDistance("All");
+              setYear("All");
+              setQuery("");
+            }}
+            className="mt-3 px-4 py-2 rounded-full text-sm font-medium text-gray-400 hover:text-white hover:bg-white/5 ring-1 ring-white/20 transition-colors"
+          >
+            Clear filters
+          </button>
+        </div>
+      )}
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {filtered.map((race) => {
@@ -85,7 +116,7 @@ export default function RaceList({ races }: { races: RaceInfo[] }) {
             <Link
               key={race.slug}
               href={`/race/${race.slug}`}
-              className="group block p-5 border border-gray-700/80 rounded-lg bg-gray-900 transition-colors duration-200 hover:border-gray-600 hover:bg-gray-800/80"
+              className="group block p-5 border border-gray-700/80 rounded-lg bg-gray-900 transition-colors duration-200 hover:border-gray-600 hover:bg-gray-800/80 [content-visibility:auto] [contain-intrinsic-size:auto_150px]"
             >
               <div className="flex items-start justify-between gap-3">
                 <h2 className="text-lg font-semibold text-white group-hover:text-blue-300 transition-colors leading-tight">

--- a/app/src/lib/__tests__/race-filter.test.ts
+++ b/app/src/lib/__tests__/race-filter.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { filterRaces, matchesRaceQuery } from "../race-filter";
+import type { RaceInfo } from "../types";
+
+const races: RaceInfo[] = [
+  {
+    slug: "im703-new-york",
+    name: "IRONMAN 70.3 New York",
+    date: "2025-09-07",
+    location: "New York, NY, United States",
+    finishers: 2100,
+  },
+  {
+    slug: "im-lake-placid",
+    name: "IRONMAN Lake Placid",
+    date: "2024-07-21",
+    location: "Lake Placid, NY, United States",
+    finishers: 1800,
+  },
+  {
+    slug: "im703-sao-paulo",
+    name: "IRONMAN 70.3 São Paulo",
+    date: "2024-04-14",
+    location: "São Paulo, Brazil",
+    finishers: 1500,
+  },
+];
+
+describe("matchesRaceQuery", () => {
+  it("matches everything when the query is empty or whitespace", () => {
+    expect(matchesRaceQuery(races[0], "")).toBe(true);
+    expect(matchesRaceQuery(races[0], "   ")).toBe(true);
+  });
+
+  it("matches by race name, case-insensitively", () => {
+    expect(matchesRaceQuery(races[1], "lake placid")).toBe(true);
+    expect(matchesRaceQuery(races[1], "LAKE")).toBe(true);
+    expect(matchesRaceQuery(races[0], "lake placid")).toBe(false);
+  });
+
+  it("matches by location, case-insensitively", () => {
+    expect(matchesRaceQuery(races[2], "brazil")).toBe(true);
+    expect(matchesRaceQuery(races[0], "united states")).toBe(true);
+    expect(matchesRaceQuery(races[2], "united states")).toBe(false);
+  });
+
+  it("matches substrings anywhere in the name or location", () => {
+    expect(matchesRaceQuery(races[0], "york")).toBe(true);
+    expect(matchesRaceQuery(races[1], "placid")).toBe(true);
+  });
+
+  it("ignores diacritics in both the query and the race fields", () => {
+    expect(matchesRaceQuery(races[2], "sao paulo")).toBe(true);
+    expect(matchesRaceQuery(races[2], "São")).toBe(true);
+    expect(matchesRaceQuery(races[0], "São")).toBe(false);
+  });
+
+  it("does not match unrelated text", () => {
+    expect(matchesRaceQuery(races[0], "kona")).toBe(false);
+  });
+});
+
+describe("filterRaces", () => {
+  it("returns all races with default filters", () => {
+    expect(filterRaces(races, { distance: "All", year: "All", query: "" })).toEqual(races);
+  });
+
+  it("filters by distance using the slug prefix", () => {
+    expect(
+      filterRaces(races, { distance: "70.3", year: "All", query: "" }).map((r) => r.slug),
+    ).toEqual(["im703-new-york", "im703-sao-paulo"]);
+    expect(
+      filterRaces(races, { distance: "140.6", year: "All", query: "" }).map((r) => r.slug),
+    ).toEqual(["im-lake-placid"]);
+  });
+
+  it("filters by year", () => {
+    expect(
+      filterRaces(races, { distance: "All", year: "2024", query: "" }).map((r) => r.slug),
+    ).toEqual(["im-lake-placid", "im703-sao-paulo"]);
+  });
+
+  it("filters by text query", () => {
+    expect(
+      filterRaces(races, { distance: "All", year: "All", query: "new york" }).map((r) => r.slug),
+    ).toEqual(["im703-new-york"]);
+  });
+
+  it("composes text query with distance and year filters", () => {
+    expect(
+      filterRaces(races, { distance: "70.3", year: "2024", query: "sao" }).map((r) => r.slug),
+    ).toEqual(["im703-sao-paulo"]);
+    expect(filterRaces(races, { distance: "140.6", year: "2024", query: "sao" })).toEqual([]);
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    expect(filterRaces(races, { distance: "All", year: "All", query: "kona" })).toEqual([]);
+  });
+});

--- a/app/src/lib/race-filter.ts
+++ b/app/src/lib/race-filter.ts
@@ -1,0 +1,41 @@
+import type { RaceInfo } from "@/lib/types";
+
+export interface RaceFilters {
+  /** "All" | "70.3" | "140.6" */
+  distance: string;
+  /** "All" or a 4-digit year */
+  year: string;
+  /** Free-text query matched against race name and location */
+  query: string;
+}
+
+/** Lowercase and strip diacritics (NFD + combining-mark removal). */
+function normalizeText(text: string): string {
+  return text
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}
+
+/**
+ * Case- and diacritic-insensitive substring match of `query` against the
+ * race's name and location. An empty/whitespace query matches everything.
+ */
+export function matchesRaceQuery(
+  race: Pick<RaceInfo, "name" | "location">,
+  query: string,
+): boolean {
+  const q = normalizeText(query.trim());
+  if (!q) return true;
+  return normalizeText(race.name).includes(q) || normalizeText(race.location).includes(q);
+}
+
+/** Applies distance, year, and text filters; used by the /races page. */
+export function filterRaces(races: RaceInfo[], filters: RaceFilters): RaceInfo[] {
+  return races.filter((race) => {
+    if (filters.distance === "70.3" && !race.slug.startsWith("im703-")) return false;
+    if (filters.distance === "140.6" && race.slug.startsWith("im703-")) return false;
+    if (filters.year !== "All" && race.date.slice(0, 4) !== filters.year) return false;
+    return matchesRaceQuery(race, filters.query);
+  });
+}


### PR DESCRIPTION
Closes #220

## Summary

- Adds a **Search** text input to the `/races` filter row that filters races by name and location as you type (client-side, over the already-loaded manifest).
- Matching is case-insensitive and diacritic-insensitive (NFD normalization + combining-mark strip), so e.g. typing `sao paulo` matches "São Paulo".
- The text filter composes with the existing distance (All / 70.3 / 140.6) and year filters, and the "Showing X of 1447 races" count updates live.
- Filter logic is extracted into a pure module `app/src/lib/race-filter.ts` (`filterRaces`, `matchesRaceQuery`); `race-list.tsx` now delegates to it instead of an inline predicate.
- New empty state: when no races match, the page shows "No races match your filters." with a **Clear filters** button (previously the grid silently rendered nothing).
- Bonus from the issue: race cards get `content-visibility: auto` (with `contain-intrinsic-size`) so offscreen cards skip layout/paint work — a one-class change that lightens the page when all 1447 cards are in the DOM.

## Test notes

- Red/green TDD: wrote `app/src/lib/__tests__/race-filter.test.ts` first (12 tests covering empty query, name/location matching, substring + case-insensitivity, diacritics, distance/year/text composition, and the empty-result case), confirmed it failed, then implemented.
- `npx vitest run`: 10 files, 97 tests, all passing.
- `npm run lint` (eslint): passes.
- `npx tsc --noEmit`: no errors in changed files (3 pre-existing errors in `athlete-shards.test.ts` exist on main and are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search functionality to filter races by name and location
  * "No races match your filters" message now displays with an option to clear all active filters

* **Performance**
  * Improved race card rendering efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->