### PR TITLE
fix: normalize all-caps athlete names at render time

### DIFF
--- a/app/src/app/athlete/[slug]/page.tsx
+++ b/app/src/app/athlete/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { getAthleteProfile } from "@/lib/athlete-shards";
 import { getCountryFlagISO } from "@/lib/flags";
+import { formatAthleteName } from "@/lib/format";
 import AthleteRaceList from "@/components/AthleteRaceList";
 
 // Edge runtime: near-zero cold start, eliminating the ~3.8s Node lambda
@@ -27,7 +28,7 @@ export default async function AthletePage({ params }: PageProps) {
       <header className="mb-8">
         <h1 className="text-3xl font-bold text-white">
           {flag && <span className="mr-2">{flag}</span>}
-          {profile.fullName}
+          {formatAthleteName(profile.fullName)}
         </h1>
         <p className="text-gray-400 mt-1">
           {profile.country} &middot; {profile.races.length} {profile.races.length === 1 ? "race" : "races"}

--- a/app/src/app/race/[slug]/page.tsx
+++ b/app/src/app/race/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getRaceBySlug, getRaceStats } from "@/lib/data";
-import { formatTime } from "@/lib/format";
+import { formatAthleteName, formatTime } from "@/lib/format";
 import { getCountryFlagISO } from "@/lib/flags";
 import dynamic from "next/dynamic";
 import ResultCard from "@/components/ResultCard";
@@ -204,7 +204,7 @@ export default async function RacePage({ params }: PageProps) {
                             href={`/race/${slug}/result/${entry.id}`}
                             className="text-white hover:text-blue-400 transition-colors"
                           >
-                            {flag} {entry.fullName}
+                            {flag} {formatAthleteName(entry.fullName)}
                           </Link>
                         </td>
                         <td className="px-4 py-2 text-gray-400 hidden lg:table-cell">{entry.ageGroup}</td>

--- a/app/src/app/race/[slug]/result/[id]/opengraph-image.tsx
+++ b/app/src/app/race/[slug]/result/[id]/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from "next/og";
 import { getRaceBySlug, getAthleteById, getAgeGroupCount } from "@/lib/data";
 import { getCountryFlagISO } from "@/lib/flags";
+import { formatAthleteName } from "@/lib/format";
 import { DISCIPLINE_COLORS } from "@/lib/colors";
 
 // Use Node runtime: getRaceBySlug / getAthleteById read from the filesystem.
@@ -72,7 +73,7 @@ export default async function Image({ params }: Params) {
         <div style={{ display: "flex", flexDirection: "column" }}>
           <div style={{ display: "flex", alignItems: "center", fontSize: 44, fontWeight: 700 }}>
             {flag ? <span style={{ marginRight: 16 }}>{flag}</span> : null}
-            {athlete.fullName}
+            {formatAthleteName(athlete.fullName)}
           </div>
           <div style={{ display: "flex", fontSize: 22, color: "#94a3b8", marginTop: 6 }}>
             {race.name} · {dateStr} · {athlete.ageGroup}

--- a/app/src/app/race/[slug]/result/[id]/page.tsx
+++ b/app/src/app/race/[slug]/result/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getRaceBySlug, getAthleteById, getGenderCount, getAgeGroupCount, getAll
 import ResultCard from "@/components/ResultCard";
 import { getCountryFlagISO } from "@/lib/flags";
 import { slugifyAthlete } from "@/lib/athlete-slug";
+import { formatAthleteName } from "@/lib/format";
 import HistogramSection, { HistogramSectionFallback } from "@/components/HistogramSection";
 import ShareDialog from "@/components/ShareDialog";
 
@@ -55,10 +56,10 @@ export default async function ResultPage({ params }: PageProps) {
             {flag && <span className="mr-2">{flag}</span>}
             {athleteSlug ? (
               <Link href={`/athlete/${athleteSlug}`} className="hover:text-blue-400 transition-colors">
-                {athlete.fullName}
+                {formatAthleteName(athlete.fullName)}
               </Link>
             ) : (
-              athlete.fullName
+              formatAthleteName(athlete.fullName)
             )}
           </h1>
           <p className="text-gray-400 mt-1">

--- a/app/src/app/stats/page.tsx
+++ b/app/src/app/stats/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { getStatsPageData } from "@/lib/data";
 import { getCountryFlagISO } from "@/lib/flags";
+import { formatAthleteName } from "@/lib/format";
 
 export const metadata = {
   title: "Stats | TriTimes",
@@ -183,7 +184,7 @@ export default function StatsPage() {
             href={`/athlete/${stats.athleteWithMostRaces.slug}`}
             className="text-lg font-semibold text-white hover:text-blue-400 transition-colors mt-1 block"
           >
-            {stats.athleteWithMostRaces.fullName}
+            {formatAthleteName(stats.athleteWithMostRaces.fullName)}
           </Link>
           <p className="text-sm text-gray-500 mt-0.5">
             {stats.athleteWithMostRaces.raceCount} races

--- a/app/src/components/CommandPalette.tsx
+++ b/app/src/components/CommandPalette.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAthleteSearch } from "@/hooks/useAthleteSearch";
 import { getCountryFlagISO } from "@/lib/flags";
+import { formatAthleteName } from "@/lib/format";
 
 export default function CommandPalette({ defaultOpen = false }: { defaultOpen?: boolean }) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
@@ -183,7 +184,7 @@ export default function CommandPalette({ defaultOpen = false }: { defaultOpen?: 
                     {getCountryFlagISO(entry.countryISO) || "\u{1F3CA}"}
                   </span>
                   <div className="min-w-0">
-                    <div className="font-medium text-white truncate">{entry.fullName}</div>
+                    <div className="font-medium text-white truncate">{formatAthleteName(entry.fullName)}</div>
                     <div className="text-sm text-gray-400">
                       {entry.country} &middot; {entry.raceCount}{" "}
                       {entry.raceCount === 1 ? "race" : "races"}

--- a/app/src/components/GlobalSearchBar.tsx
+++ b/app/src/components/GlobalSearchBar.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAthleteSearch } from "@/hooks/useAthleteSearch";
 import { AthleteSearchEntry } from "@/lib/types";
+import { formatAthleteName } from "@/lib/format";
 
 export type GlobalSearchViewState = "closed" | "loading" | "empty" | "results";
 
@@ -110,7 +111,7 @@ export default function GlobalSearchBar() {
                   }}
                   className="block px-4 py-3"
                 >
-                  <div className="font-medium text-white">{entry.fullName}</div>
+                  <div className="font-medium text-white">{formatAthleteName(entry.fullName)}</div>
                   <div className="text-sm text-gray-400">
                     {entry.country} &middot; {entry.raceCount} {entry.raceCount === 1 ? "race" : "races"}
                   </div>

--- a/app/src/lib/__tests__/format.test.ts
+++ b/app/src/lib/__tests__/format.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { formatAthleteName } from "../format";
+
+describe("formatAthleteName", () => {
+  it("title-cases an all-caps surname", () => {
+    expect(formatAthleteName("MULLER Nicolas")).toBe("Muller Nicolas");
+  });
+
+  it("title-cases a fully all-caps name", () => {
+    expect(formatAthleteName("MULLER NICOLAS")).toBe("Muller Nicolas");
+  });
+
+  it("leaves an already title-cased name unchanged", () => {
+    expect(formatAthleteName("Muller Alain")).toBe("Muller Alain");
+  });
+
+  it("leaves correctly mixed-case names unchanged", () => {
+    expect(formatAthleteName("McDonald Ian")).toBe("McDonald Ian");
+    expect(formatAthleteName("van der Berg Jan")).toBe("van der Berg Jan");
+  });
+
+  it("handles hyphenated all-caps tokens", () => {
+    expect(formatAthleteName("SMITH-JONES Anna")).toBe("Smith-Jones Anna");
+  });
+
+  it("handles apostrophes in all-caps tokens", () => {
+    expect(formatAthleteName("O'BRIEN Patrick")).toBe("O'Brien Patrick");
+  });
+
+  it("restores Mc prefixes in all-caps tokens", () => {
+    expect(formatAthleteName("MCDONALD Ian")).toBe("McDonald Ian");
+  });
+
+  it("does not special-case Mac prefixes", () => {
+    expect(formatAthleteName("MACDONALD Ian")).toBe("Macdonald Ian");
+  });
+
+  it("handles accented uppercase letters", () => {
+    expect(formatAthleteName("MÜLLER Hans")).toBe("Müller Hans");
+    expect(formatAthleteName("GARCÍA José")).toBe("García José");
+  });
+
+  it("leaves single-letter initials untouched", () => {
+    expect(formatAthleteName("SMITH J")).toBe("Smith J");
+    expect(formatAthleteName("SMITH J.")).toBe("Smith J.");
+  });
+
+  it("title-cases two-letter all-caps tokens", () => {
+    expect(formatAthleteName("NG JJ")).toBe("Ng Jj");
+  });
+
+  it("handles empty strings", () => {
+    expect(formatAthleteName("")).toBe("");
+  });
+
+  it("preserves whitespace exactly", () => {
+    expect(formatAthleteName("MULLER  Nicolas")).toBe("Muller  Nicolas");
+  });
+});

--- a/app/src/lib/format.ts
+++ b/app/src/lib/format.ts
@@ -1,3 +1,46 @@
+/**
+ * Normalizes display casing of athlete names scraped from ironman.com.
+ *
+ * Only tokens that are FULLY uppercase (with at least two letters) are
+ * title-cased; mixed-case tokens ("McDonald", "van der Berg") are left
+ * untouched. When lowering an all-caps token, hyphenated and
+ * apostrophe-separated parts are each title-cased ("SMITH-JONES" ->
+ * "Smith-Jones", "O'BRIEN" -> "O'Brien") and "Mc" prefixes are restored
+ * ("MCDONALD" -> "McDonald"). "Mac" is ambiguous and intentionally not
+ * special-cased. Accented uppercase letters are handled ("MÜLLER" ->
+ * "Müller").
+ */
+export function formatAthleteName(name: string): string {
+  return name
+    .split(/(\s+)/)
+    .map((token) => (isAllCaps(token) ? titleCaseToken(token) : token))
+    .join("");
+}
+
+/** True when the token has >= 2 letters and every letter is uppercase. */
+function isAllCaps(token: string): boolean {
+  const letters = token.match(/\p{L}/gu);
+  if (!letters || letters.length < 2) return false;
+  return letters.every((c) => c !== c.toLowerCase() && c === c.toUpperCase());
+}
+
+function titleCaseToken(token: string): string {
+  return token
+    .split(/([-'’])/)
+    .map(titleCasePart)
+    .join("");
+}
+
+function titleCasePart(part: string): string {
+  if (!part) return part;
+  const lower = part.toLowerCase();
+  const cased = lower.charAt(0).toUpperCase() + lower.slice(1);
+  if (/^Mc\p{Ll}/u.test(cased)) {
+    return `Mc${cased.charAt(2).toUpperCase()}${cased.slice(3)}`;
+  }
+  return cased;
+}
+
 export function formatTime(seconds: number): string {
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);


### PR DESCRIPTION
Closes #224

## Summary

Athlete names scraped from ironman.com have inconsistent casing, so search results showed "MULLER Nicolas" next to "Muller Alain", and the all-caps entries carried through to profile, result, and race pages.

This is a purely render-time fix (no data files, index scripts, or search/matching logic touched, to avoid conflicts with #218):

- New pure helper `formatAthleteName` in `app/src/lib/format.ts`:
  - Only transforms tokens that are fully uppercase with 2+ letters ("MULLER" → "Muller"); mixed-case tokens like "McDonald" and "van der Berg" are left untouched
  - Handles hyphenated parts ("SMITH-JONES" → "Smith-Jones"), apostrophes ("O'BRIEN" → "O'Brien"), "Mc" prefixes ("MCDONALD" → "McDonald"; "Mac" intentionally not special-cased as it's ambiguous), and accented uppercase ("MÜLLER" → "Müller")
  - Single-letter initials are preserved
- Applied at every athlete-name render site:
  - `GlobalSearchBar` search results (display only)
  - `CommandPalette` search results
  - Athlete profile page heading (`/athlete/[slug]`)
  - Result page heading (`/race/[slug]/result/[id]`) and its OG share image
  - Top-finisher tables on the race page (`/race/[slug]`)
  - Stats page ("Athlete with Most Races")

## Test notes

- Red/green TDD: added `app/src/lib/__tests__/format.test.ts` (13 cases: all-caps surname, already-correct names unchanged, hyphen/apostrophe/Mc/Mac, accented caps, initials, whitespace preservation) — written first and confirmed failing, then implemented
- `npx vitest run`: 10 files, 98 tests, all passing
- `npm run lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Athlete names are now displayed with consistent, readable title casing across athlete profiles, race pages (top finishers), race result pages, OpenGraph previews, statistics, and search (including the command palette and global search).
  * Proper handling of complex name formats (e.g., hyphens, apostrophes, “Mc” capitalization, accented characters, and whitespace) ensures more accurate display.
* **Tests**
  * Added automated coverage for the name-formatting behavior across common and edge-case inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->