### PR TITLE
fix: cap percentile chips at >99% and clarify beat-percentage meaning

### DIFF
--- a/app/src/components/PercentilePill.tsx
+++ b/app/src/components/PercentilePill.tsx
@@ -1,23 +1,26 @@
 import { formatPercentile } from "@/lib/percentile";
 
 interface PercentilePillProps {
-  /** Raw percentile value (1-100); 0 means no data. */
+  /** Raw percentile value (share of field beaten, 0-100); 0 means no data. */
   percentile: number;
-  /** Optional aria-label override; defaults to "Age group top X%". */
+  /** Optional tooltip/aria-label override; defaults to "Faster than X% of age group". */
   label?: string;
 }
 
 /**
- * Small amber pill showing the athlete's age-group percentile for a discipline.
- * Reference is implicit (age group) — page context conveys it.
+ * Small amber pill showing the share of the athlete's age group they beat for a
+ * discipline (higher is better). Note this is the opposite convention from the
+ * "Top X%" summary cards, so the tooltip spells out the meaning.
  */
 export default function PercentilePill({ percentile, label }: PercentilePillProps) {
   const text = formatPercentile(percentile);
-  const ariaLabel = label ?? (text === "—" ? "Percentile unavailable" : `Age group top ${text}`);
+  const description =
+    label ?? (text === "—" ? "Percentile unavailable" : `Faster than ${text} of age group`);
   return (
     <span
       className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-bold rounded-full bg-amber-400/15 text-amber-400 tabular-nums"
-      aria-label={ariaLabel}
+      aria-label={description}
+      title={description}
     >
       {text}
     </span>

--- a/app/src/lib/__tests__/percentile.test.ts
+++ b/app/src/lib/__tests__/percentile.test.ts
@@ -6,7 +6,30 @@ describe("formatPercentile", () => {
     expect(formatPercentile(22)).toBe("22%");
     expect(formatPercentile(1)).toBe("1%");
     expect(formatPercentile(99)).toBe("99%");
-    expect(formatPercentile(100)).toBe("100%");
+    expect(formatPercentile(88)).toBe("88%");
+  });
+
+  it("rounds fractional percentiles", () => {
+    expect(formatPercentile(87.6)).toBe("88%");
+    expect(formatPercentile(88.4)).toBe("88%");
+  });
+
+  it("caps the winner at >99% instead of an impossible 100%", () => {
+    // e.g. Hamburg winner: beat 2177 of 2178 = 99.954% — must not round to 100%
+    expect(formatPercentile((2177 / 2178) * 100)).toBe(">99%");
+    expect(formatPercentile(99.6)).toBe(">99%");
+    expect(formatPercentile(100)).toBe(">99%");
+  });
+
+  it("shows <1% at the bottom end instead of 0%", () => {
+    // e.g. second-to-last: beat 1 of 300 = 0.33% — must not round to 0%
+    expect(formatPercentile((1 / 300) * 100)).toBe("<1%");
+    expect(formatPercentile(0.4)).toBe("<1%");
+  });
+
+  it("does not cap values that round inside 1-99", () => {
+    expect(formatPercentile(99.4)).toBe("99%");
+    expect(formatPercentile(0.5)).toBe("1%");
   });
 
   it("renders an em-dash for 0 (treated as no data)", () => {

--- a/app/src/lib/data.ts
+++ b/app/src/lib/data.ts
@@ -385,9 +385,11 @@ export function computeHistogram(
     });
   }
 
-  // Percentile: percentage of finishers the athlete beat (higher = better)
+  // Percentile: percentage of finishers the athlete beat (higher = better).
+  // Left unrounded so the display layer (formatPercentile) can distinguish
+  // e.g. 99.95% (winner, shown as ">99%") from a true 100%.
   const slowerCount = valid.filter((s) => s > athleteSeconds).length;
-  const athletePercentile = Math.round((slowerCount / valid.length) * 100);
+  const athletePercentile = (slowerCount / valid.length) * 100;
 
   const medianSeconds = computeMedian(valid);
 
@@ -488,8 +490,9 @@ export function getDisciplineHistogram(
         (sum: number, b: PrecomputedBin) => sum + (b.rangeStart > athleteSeconds ? b.count : 0),
         0
       );
+      // Unrounded — display rounding/capping happens in formatPercentile.
       const athletePercentile = source.totalAthletes > 0
-        ? Math.round((slowerCount / source.totalAthletes) * 100)
+        ? (slowerCount / source.totalAthletes) * 100
         : 0;
 
       return { bins, athleteSeconds, athletePercentile, medianSeconds: source.medianSeconds };

--- a/app/src/lib/percentile.ts
+++ b/app/src/lib/percentile.ts
@@ -1,10 +1,19 @@
 /**
  * Format a raw percentile value (as returned by getDisciplineHistogram) for UI display.
+ *
+ * The value is the share of the field the athlete beat (higher is better) and may be
+ * fractional. It is rounded here for display, but capped so the chip never shows an
+ * impossible extreme: a race winner (e.g. 2177/2178 = 99.95%) renders as ">99%" rather
+ * than "100%", and a back-of-pack finisher renders as "<1%" rather than "0%".
+ *
  * A value of 0 is treated as "no data available" because getDisciplineHistogram returns 0
- * when the histogram is missing or empty — a true 0th-percentile finish is essentially
- * impossible (you'd have to be infinitely fast).
+ * when the histogram is missing or empty (a finisher who beat at least one athlete always
+ * has a strictly positive value).
  */
 export function formatPercentile(percentile: number): string {
   if (!Number.isFinite(percentile) || percentile <= 0) return "—";
-  return `${percentile}%`;
+  const rounded = Math.round(percentile);
+  if (rounded >= 100) return ">99%";
+  if (rounded < 1) return "<1%";
+  return `${rounded}%`;
 }


### PR DESCRIPTION
Closes #225

## Summary

On a result page the per-discipline chips (share of field beaten, higher is better) sat a few pixels from the "Top 1%" summary cards (lower is better), and for a race winner the chip rounded 2177/2178 up to an impossible-looking "100%".

- `formatPercentile` now rounds for display and caps the extremes: values rounding to 100 render as **">99%"** and positive values rounding to 0 render as **"<1%"** instead of "0%".
- `getDisciplineHistogram` / `computeHistogram` no longer pre-round `athletePercentile`, so the formatter can distinguish 99.95% (winner) from a true 100%, and 0.33% (near last) from the 0 "no data" sentinel.
- `PercentilePill` gains a `title` tooltip ("Faster than 88% of age group") and a corrected `aria-label` — the old one said "Age group top 88%", which inverted the meaning relative to the displayed value. The "Top X%" summary cards are unchanged.

## Test notes

Red/green TDD: extended `app/src/lib/__tests__/percentile.test.ts` first (winner → ">99%", near-last → "<1%", fractional rounding, no-cap for in-range values), confirmed 4 failures, then implemented.

- `npx vitest run`: 89 tests passing (9 files)
- `npm run lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved percentile indicator tooltip messaging for greater clarity.

* **Improvements**
  * Percentile values now display with proper rounding and boundary clamping (displays >99% and <1% for edge cases instead of 100% and 0%).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->