### PR TITLE
fix: make athlete search diacritic-insensitive

### DIFF
--- a/app/src/lib/__tests__/client-search-index.test.ts
+++ b/app/src/lib/__tests__/client-search-index.test.ts
@@ -38,6 +38,13 @@ describe("parseIndexTsv", () => {
     expect(parseIndexTsv(tsv)[0].fullNameLower).toBe("foo bar");
   });
 
+  it("folds diacritics into fullNameLower but keeps fullName accented", () => {
+    const tsv = "beni-muller--ch-m\tMüller Beni\tSwitzerland\tCH\t2";
+    const [entry] = parseIndexTsv(tsv);
+    expect(entry.fullNameLower).toBe("muller beni");
+    expect(entry.fullName).toBe("Müller Beni");
+  });
+
   it("parses raceCount as a number", () => {
     const tsv = "x\tx\tx\tXX\t42";
     expect(parseIndexTsv(tsv)[0].raceCount).toBe(42);

--- a/app/src/lib/__tests__/search-core.test.ts
+++ b/app/src/lib/__tests__/search-core.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildSearchKeys,
+  foldName,
   searchAthletesInIndex,
   type IndexEntry,
 } from "../search-core";
@@ -79,6 +80,79 @@ describe("searchAthletesInIndex (core)", () => {
 
   it("respects the limit", () => {
     expect(searchAthletesInIndex("s", athletes, keys, 1).length).toBe(1);
+  });
+});
+
+describe("foldName", () => {
+  it("lowercases and strips combining diacritics", () => {
+    expect(foldName("Müller")).toBe("muller");
+    expect(foldName("Németh")).toBe("nemeth");
+    expect(foldName("Pierré")).toBe("pierre");
+    expect(foldName("Åse")).toBe("ase");
+    expect(foldName("João")).toBe("joao");
+  });
+
+  it("folds special letters that have no NFD decomposition", () => {
+    expect(foldName("Thronæs")).toBe("thronaes");
+    expect(foldName("Søren")).toBe("soren");
+    expect(foldName("Großmann")).toBe("grossmann");
+    expect(foldName("Đorđe")).toBe("dorde");
+    expect(foldName("Guðrún")).toBe("gudrun");
+    expect(foldName("Þór")).toBe("thor");
+    expect(foldName("Łukasz")).toBe("lukasz");
+    expect(foldName("Œuvre")).toBe("oeuvre");
+  });
+
+  it("leaves plain ASCII names untouched", () => {
+    expect(foldName("John Smith")).toBe("john smith");
+  });
+});
+
+describe("diacritic-insensitive search", () => {
+  function entry(slug: string, fullName: string): IndexEntry {
+    return {
+      slug,
+      fullName,
+      fullNameLower: foldName(fullName),
+      country: "Switzerland",
+      countryISO: "CH",
+      raceCount: 1,
+    };
+  }
+  // Sorted by folded fullNameLower (binary-search precondition).
+  const athletes: IndexEntry[] = [
+    entry("alain-muller", "Muller Alain"),
+    entry("beni-muller", "Müller Beni"),
+    entry("zsolt-nemeth", "Németh Zsolt"),
+  ];
+  const keys = buildSearchKeys(athletes);
+
+  it("finds accented names from an unaccented query", () => {
+    expect(searchAthletesInIndex("muller", athletes, keys)).toMatchObject([
+      { slug: "alain-muller" },
+      { slug: "beni-muller" },
+    ]);
+    expect(searchAthletesInIndex("nemeth", athletes, keys)).toMatchObject([
+      { slug: "zsolt-nemeth" },
+    ]);
+  });
+
+  it("finds unaccented names from an accented query", () => {
+    expect(searchAthletesInIndex("müller", athletes, keys)).toMatchObject([
+      { slug: "alain-muller" },
+      { slug: "beni-muller" },
+    ]);
+  });
+
+  it("matches rotated tokens diacritic-insensitively", () => {
+    expect(searchAthletesInIndex("beni mü", athletes, keys)).toMatchObject([
+      { slug: "beni-muller" },
+    ]);
+  });
+
+  it("keeps the accented display name in results", () => {
+    const results = searchAthletesInIndex("muller be", athletes, keys);
+    expect(results).toMatchObject([{ fullName: "Müller Beni" }]);
   });
 });
 

--- a/app/src/lib/__tests__/search-index.test.ts
+++ b/app/src/lib/__tests__/search-index.test.ts
@@ -177,4 +177,30 @@ describe("searchAthletes (shard-backed)", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(gzippedResponse(SMITH_TSV));
     expect(await searchAthletes("smith", 1)).toHaveLength(1);
   });
+
+  it("matches accented names from an unaccented query (and vice versa)", async () => {
+    const MULLER_TSV = [
+      "alain-muller--fr-m\tMuller Alain\tFrance\tFR\t1",
+      "beni-muller--ch-m\tMüller Beni\tSwitzerland\tCH\t2",
+    ].join("\n");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(gzippedResponse(MULLER_TSV));
+
+    expect(await searchAthletes("muller", 10)).toMatchObject([
+      { slug: "alain-muller--fr-m" },
+      { slug: "beni-muller--ch-m", fullName: "Müller Beni" },
+    ]);
+
+    // The accented query folds to the same "mu" bucket and shard.
+    expect(await searchAthletes("müller", 10)).toMatchObject([
+      { slug: "alain-muller--fr-m" },
+      { slug: "beni-muller--ch-m" },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3000/search-shards/6d75.tsv.gz",
+      expect.anything(),
+    );
+  });
 });

--- a/app/src/lib/__tests__/search-shards.test.ts
+++ b/app/src/lib/__tests__/search-shards.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  foldName,
   searchBucket,
   shardFileName,
   buildSearchKeys,
@@ -37,6 +38,12 @@ describe("searchBucket (query → 2-char bucket)", () => {
   it("keeps an inner space in single-letter-token queries", () => {
     expect(searchBucket("a b")).toBe("a ");
   });
+
+  it("folds diacritics so accented queries map to the ASCII bucket", () => {
+    expect(searchBucket("Müller")).toBe("mu");
+    expect(searchBucket("Þór")).toBe("th");
+    expect(searchBucket("ß")).toBe("ss");
+  });
 });
 
 describe("shardFileName", () => {
@@ -70,6 +77,29 @@ describe("build script parity", () => {
     const keys = buildSearchKeys(entries);
     const expected = new Set(keys.map((k) => k.key.slice(0, 2)));
     expect(new Set(buildShards.bucketsForName("john smith"))).toEqual(expected);
+  });
+
+  it("script foldName matches search-core foldName", () => {
+    for (const name of [
+      "Müller Beni",
+      "Németh Zsolt",
+      "Thronæs",
+      "Søren",
+      "Großmann",
+      "Đorđe",
+      "Þór",
+      "Łukasz",
+      "John Smith",
+    ]) {
+      expect(buildShards.foldName(name)).toBe(foldName(name));
+    }
+  });
+
+  it("matches pinned folded values (build/runtime parity anchor)", () => {
+    // Hardcoded so any drift between the script and search-core is caught.
+    expect(buildShards.foldName("Müller")).toBe("muller");
+    expect(buildShards.foldName("Thronæs")).toBe("thronaes");
+    expect(buildShards.foldName("Großmann")).toBe("grossmann");
   });
 });
 
@@ -115,9 +145,9 @@ describe("buildShardMap", () => {
     expect(jo).toEqual(["john-smith", "zoe-jones"]);
   });
 
-  it("sorts shard lines by code-unit fullNameLower (binary-search precondition)", () => {
+  it("sorts shard lines by code-unit folded name (binary-search precondition)", () => {
     for (const lines of shards.values()) {
-      const names = lines.map((l: string) => l.split("\t")[1].toLowerCase());
+      const names = lines.map((l: string) => foldName(l.split("\t")[1]));
       const sorted = [...names].sort();
       expect(names).toEqual(sorted);
     }
@@ -147,5 +177,50 @@ describe("buildShardMap", () => {
       const fromFull = searchAthletesInIndex(query, entries, buildSearchKeys(entries), 10);
       expect(fromShard).toEqual(fromFull);
     }
+  });
+});
+
+describe("buildShardMap diacritic folding", () => {
+  const lines = [
+    "beni-muller--ch-m\tMüller Beni\tSwitzerland\tCH\t2",
+    "alain-muller--fr-m\tMuller Alain\tFrance\tFR\t1",
+    "trygve-thronaes--no-m\tThronæs Trygve\tNorway\tNO\t1",
+  ];
+  const shards = buildShards.buildShardMap(lines);
+
+  it("buckets accented names under their folded ASCII prefix", () => {
+    const mu = shards.get("mu").map((l: string) => l.split("\t")[0]);
+    expect(mu).toEqual(["alain-muller--fr-m", "beni-muller--ch-m"]);
+    expect(shards.has("mü")).toBe(false);
+  });
+
+  it("buckets æ-names so a folded 'ae' query can reach them", () => {
+    expect(shards.get("th").map((l: string) => l.split("\t")[0])).toEqual([
+      "trygve-thronaes--no-m",
+    ]);
+  });
+
+  it("serves both accented and ASCII names for an unaccented query", () => {
+    const bucket = searchBucket("muller")!;
+    const shardEntries: IndexEntry[] = shards
+      .get(bucket)
+      .map((l: string) => {
+        const [slug, fullName, country, countryISO, raceCount] = l.split("\t");
+        return {
+          slug,
+          fullName,
+          fullNameLower: foldName(fullName),
+          country,
+          countryISO,
+          raceCount: +raceCount,
+        };
+      });
+    const results = searchAthletesInIndex(
+      "muller",
+      shardEntries,
+      buildSearchKeys(shardEntries),
+      10,
+    );
+    expect(results.map((r) => r.fullName)).toEqual(["Muller Alain", "Müller Beni"]);
   });
 });

--- a/app/src/lib/client-search-index.ts
+++ b/app/src/lib/client-search-index.ts
@@ -1,6 +1,7 @@
 import { AthleteSearchEntry } from "@/lib/types";
 import {
   buildSearchKeys,
+  foldName,
   searchAthletesInIndex,
   searchBucket,
   shardFileName,
@@ -28,7 +29,7 @@ export function parseIndexTsv(tsv: string): IndexEntry[] {
     entries.push({
       slug: line.substring(0, t1),
       fullName,
-      fullNameLower: fullName.toLowerCase(),
+      fullNameLower: foldName(fullName),
       country: line.substring(t2 + 1, t3),
       countryISO: line.substring(t3 + 1, t4),
       raceCount: +line.substring(t4 + 1),

--- a/app/src/lib/search-core.ts
+++ b/app/src/lib/search-core.ts
@@ -1,6 +1,7 @@
 import { AthleteSearchEntry } from "@/lib/types";
 
 export interface IndexEntry extends AthleteSearchEntry {
+  /** Match field: lowercased AND diacritic-folded — see foldName(). */
   fullNameLower: string;
 }
 
@@ -19,8 +20,37 @@ function toSearchResult(entry: IndexEntry): AthleteSearchEntry {
   };
 }
 
+// Lowercase letters with no NFD decomposition that still need ASCII folding.
+const FOLD_SPECIALS: Record<string, string> = {
+  "æ": "ae",
+  "œ": "oe",
+  "ø": "o",
+  "ß": "ss",
+  "đ": "d",
+  "ð": "d",
+  "þ": "th",
+  "ł": "l",
+};
+
+/**
+ * Lowercase a name and fold diacritics for search matching: NFD-strip
+ * combining marks (ü→u, é→e, å→a) plus the special cases above (æ→ae, ø→o,
+ * ß→ss, …). Applied to indexed names, shard keys, and queries alike so
+ * "muller" matches "Müller" and vice versa. Display names stay accented —
+ * only match fields are folded.
+ * MUST stay identical to foldName() in scripts/build-search-shards.js — see
+ * search-shards.test.ts.
+ */
+export function foldName(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[æœøßđðþł]/g, (ch) => FOLD_SPECIALS[ch]);
+}
+
 function normalizeQuery(query: string): string {
-  return query.toLowerCase().trim().replace(/\s+/g, " ");
+  return foldName(query).trim().replace(/\s+/g, " ");
 }
 
 /**

--- a/app/src/lib/search-index.ts
+++ b/app/src/lib/search-index.ts
@@ -2,6 +2,7 @@ import { gunzipSync } from "zlib";
 import { AthleteSearchEntry } from "@/lib/types";
 import {
   buildSearchKeys,
+  foldName,
   searchAthletesInIndex as searchAthletesInIndexCore,
   searchBucket,
   shardFileName,
@@ -81,7 +82,7 @@ function parseShardTsv(tsv: string): IndexEntry[] {
     entries.push({
       slug: line.substring(0, t1),
       fullName,
-      fullNameLower: fullName.toLowerCase(),
+      fullNameLower: foldName(fullName),
       country: line.substring(t2 + 1, t3),
       countryISO: line.substring(t3 + 1, t4),
       raceCount: +line.substring(t4 + 1),

--- a/scripts/build-search-shards.js
+++ b/scripts/build-search-shards.js
@@ -4,8 +4,9 @@
  * Builds prefix-sharded athlete search indexes for typeahead search:
  *   app/public/search-shards/<hex>.tsv.gz
  *
- * Each shard holds every athlete whose search keys (lowercased full name plus
- * token rotations, mirroring buildSearchKeys in app/src/lib/search-core.ts)
+ * Each shard holds every athlete whose search keys (diacritic-folded
+ * lowercase full name plus token rotations, mirroring buildSearchKeys in
+ * app/src/lib/search-core.ts)
  * start with one 2-char prefix, so a query only ever needs the one shard for
  * its first two normalized chars (~0.2KB–1MB gz) instead of the full 9.7MB
  * index. Used by both the browser and /api/search.
@@ -32,7 +33,31 @@ function shardFileName(bucket) {
   return `${Buffer.from(bucket, "utf8").toString("hex")}.tsv.gz`;
 }
 
-// Mirrors buildSearchKeys() in app/src/lib/search-core.ts: the lowercased
+// Lowercase letters with no NFD decomposition that still need ASCII folding.
+const FOLD_SPECIALS = {
+  "æ": "ae",
+  "œ": "oe",
+  "ø": "o",
+  "ß": "ss",
+  "đ": "d",
+  "ð": "d",
+  "þ": "th",
+  "ł": "l",
+};
+
+// Lowercase + fold diacritics so shard keys and sort order are
+// diacritic-insensitive ("Müller" lands in the "mu" shard, sorted with
+// "Muller"). MUST stay identical to foldName() in app/src/lib/search-core.ts
+// — see search-shards.test.ts. Display names in the shard lines stay accented.
+function foldName(name) {
+  return name
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[æœøßđðþł]/g, (ch) => FOLD_SPECIALS[ch]);
+}
+
+// Mirrors buildSearchKeys() in app/src/lib/search-core.ts: the folded
 // full name plus every rotation of its tokens (so "smith" finds "John Smith").
 function searchKeysForName(nameLower) {
   const tokens = nameLower.split(/[\s-]+/).filter(Boolean);
@@ -63,7 +88,7 @@ function buildShardMap(lines) {
     if (!line) continue;
     const t1 = line.indexOf("\t");
     const t2 = line.indexOf("\t", t1 + 1);
-    const nameLower = line.substring(t1 + 1, t2).toLowerCase();
+    const nameLower = foldName(line.substring(t1 + 1, t2));
     for (const bucket of bucketsForName(nameLower)) {
       let shard = shards.get(bucket);
       if (!shard) {
@@ -135,4 +160,4 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { shardFileName, searchKeysForName, bucketsForName, buildShardMap };
+module.exports = { shardFileName, foldName, searchKeysForName, bucketsForName, buildShardMap };


### PR DESCRIPTION
Closes #218

## Summary

Athlete search was diacritic-sensitive: typing `muller` did not find "Müller" and `müller` did not find ASCII "Muller". The match field was plain `.toLowerCase()` and shard keys were derived from the same unfolded string, so `mu` and `mü` even landed in different shards.

This PR adds `foldName()` — lowercase + NFD strip of combining marks (`ü→u`, `é→e`, `å→a`) plus special cases with no decomposition (`æ→ae`, `œ→oe`, `ø→o`, `ß→ss`, `đ→d`, `ð→d`, `þ→th`, `ł→l`) — and applies it consistently to:

- **the query**: `normalizeQuery()` in `app/src/lib/search-core.ts`, so `searchBucket()` folds too (an accented query maps to the ASCII shard)
- **the per-entry match field**: `parseIndexTsv()` (client) and `parseShardTsv()` (`/api/search` fallback) now build `fullNameLower` via `foldName()`
- **shard bucketing and sort order**: `scripts/build-search-shards.js` folds the name before deriving 2-char buckets and sorting shard lines, so "Müller" lands in the `mu` shard sorted alongside "Muller"

The script duplicates `foldName` as a small zero-dependency pure function (same pattern as the existing `shardFileName`/`bucketsForName` mirrors), with build/runtime parity pinned by tests.

Folding happens at shard-build time and query time, so the committed `data/athlete-index.tsv.gz` is untouched — no index regeneration needed. Display names stay accented; only match fields are folded. Display-casing is intentionally untouched (#224 covers that).

## Testing

Red/green TDD — the new tests were written first and failed (8 failures), then the fix turned them green:

- `npx vitest run`: **100/100 passed** — new coverage includes `foldName` unit tests, `muller` ⇄ `Müller` matching both directions, rotated-token accented queries, accented display names preserved, script-vs-core fold parity (including pinned anchors), folded shard bucketing/sorting, and a shard-backed `searchAthletes` round trip showing both queries hit the same `mu` (`6d75.tsv.gz`) shard
- `npm run lint`: clean
- Real-data check: rebuilt shards from the committed index — 547 Muller/Müller entries now share the `mu` shard (previously split across `mu`/`mü`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search is now diacritic-insensitive: queries match results regardless of accents (e.g., searching "muller" finds "Müller" and vice versa). Display results preserve original accented names.

* **Tests**
  * Added comprehensive test coverage for diacritic-insensitive search functionality across all search layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->