### PR TITLE
fix: exclude Pros from course charts and stop clipping Y-axis labels

### DIFF
--- a/app/src/app/courses/course-charts.tsx
+++ b/app/src/app/courses/course-charts.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import dynamic from "next/dynamic";
 import type { CourseStats } from "@/lib/types";
 import { DISCIPLINE_COLORS } from "@/lib/colors";
+import { isProCourse } from "@/components/chart-utils";
 
 const CourseBarChart = dynamic(() => import("@/components/CourseBarChart"), {
   ssr: false,
@@ -48,7 +49,8 @@ export default function CourseCharts({
   const filtered = courses.filter(
     (c) =>
       c.distance === distance &&
-      !c.course.includes("world-championship")
+      !c.course.includes("world-championship") &&
+      !isProCourse(c.displayName)
   );
 
   const btnClass = (active: boolean) =>

--- a/app/src/components/CourseBarChart.tsx
+++ b/app/src/components/CourseBarChart.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef } from "react";
 import type { CourseStats } from "@/lib/types";
+import { truncateLabel } from "./chart-utils";
 
 function formatTime(seconds: number): string {
   const h = Math.floor(seconds / 3600);
@@ -28,7 +29,14 @@ interface Props {
 const SVG_WIDTH = 500;
 const BAR_HEIGHT = 24;
 const BAR_SPACING = 36;
-const MARGIN = { top: 5, right: 10, bottom: 25, left: 100 };
+const MARGIN = { top: 5, right: 10, bottom: 25, left: 124 };
+const LABEL_FONT_SIZE = 11;
+// Gutter available for the race-name labels, in viewBox units.
+const LABEL_GUTTER = MARGIN.left - 5;
+// Approximate width of a character at LABEL_FONT_SIZE; used to cap label length
+// so names never hard-clip past the left edge of the SVG.
+const APPROX_CHAR_WIDTH = 6;
+const MAX_LABEL_CHARS = Math.floor(LABEL_GUTTER / APPROX_CHAR_WIDTH);
 
 export default function CourseBarChart({
   courses,
@@ -117,9 +125,9 @@ export default function CourseBarChart({
                   y={y + BAR_HEIGHT / 2 + 4}
                   textAnchor="end"
                   fill="#d1d5db"
-                  fontSize="11"
+                  fontSize={LABEL_FONT_SIZE}
                 >
-                  {d.name}
+                  {truncateLabel(d.name, MAX_LABEL_CHARS)}
                 </text>
                 <rect
                   x={MARGIN.left}

--- a/app/src/components/__tests__/chart-utils.test.ts
+++ b/app/src/components/__tests__/chart-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { cursorXToDataIndex, computeLabelStep } from "../chart-utils";
+import {
+  cursorXToDataIndex,
+  computeLabelStep,
+  isProCourse,
+  truncateLabel,
+} from "../chart-utils";
 
 const MARGIN = { left: 55, right: 10 };
 const VIEW_BOX = { width: 500, height: 250 };
@@ -107,5 +112,43 @@ describe("computeLabelStep", () => {
     const step40 = computeLabelStep({ dataLength: 40, plotWidthPx: 435, minLabelSpacingPx: MIN_SPACING });
     expect(step20).toBeGreaterThanOrEqual(3);
     expect(step40).toBeGreaterThanOrEqual(step20);
+  });
+});
+
+describe("isProCourse", () => {
+  it("flags courses whose display name ends with the Pros suffix", () => {
+    expect(isProCourse("Dallas-Little Elm - Pros")).toBe(true);
+    expect(isProCourse("Davao - Pros")).toBe(true);
+  });
+
+  it("does not flag age-group courses", () => {
+    expect(isProCourse("Melbourne")).toBe(false);
+    expect(isProCourse("Berlin-Brandenburg")).toBe(false);
+    expect(isProCourse("Punta del Este")).toBe(false);
+  });
+
+  it("only matches the trailing ' - Pros' suffix, not the word elsewhere", () => {
+    expect(isProCourse("Pros Valley")).toBe(false);
+    expect(isProCourse("Prosser")).toBe(false);
+  });
+});
+
+describe("truncateLabel", () => {
+  it("leaves labels at or under the limit unchanged", () => {
+    expect(truncateLabel("Melbourne", 18)).toBe("Melbourne");
+    expect(truncateLabel("Berlin-Brandenburg", 18)).toBe("Berlin-Brandenburg");
+  });
+
+  it("truncates longer labels to the limit with an ellipsis", () => {
+    const out = truncateLabel("Berlin-Brandenburg Extra Long", 18);
+    expect(out.length).toBeLessThanOrEqual(18);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("does not leave a trailing space before the ellipsis", () => {
+    // "Sunshine Coast XY" cut at 15 chars would land mid-space; trim it.
+    const out = truncateLabel("Sunshine Coast XYZ", 15);
+    expect(out).not.toMatch(/ …$/);
+    expect(out.endsWith("…")).toBe(true);
   });
 });

--- a/app/src/components/chart-utils.ts
+++ b/app/src/components/chart-utils.ts
@@ -29,6 +29,20 @@ export function cursorXToDataIndex(opts: {
   return Math.max(0, Math.min(dataLength - 1, idx));
 }
 
+// Pro-only courses are scraped as separate races whose name ends in " - Pros".
+// They don't belong in age-grouper course comparisons because pros are faster.
+export function isProCourse(displayName: string): boolean {
+  return displayName.endsWith(" - Pros");
+}
+
+// Truncate a label to fit the chart's label gutter, appending an ellipsis when
+// it overflows. The full name is still shown in the tooltip.
+export function truncateLabel(name: string, maxChars: number): string {
+  if (name.length <= maxChars) return name;
+  if (maxChars <= 1) return "…";
+  return name.slice(0, maxChars - 1).trimEnd() + "…";
+}
+
 // Choose how many data labels to draw between visible ticks so adjacent labels
 // don't collide. Returns the step (1 = every label).
 export function computeLabelStep(opts: {


### PR DESCRIPTION
## What

On the `/courses` page:

1. **Exclude Pro-only races from the difficulty charts.** Pro fields are scraped as separate races whose name ends in `" - Pros"` (e.g. Dallas-Little Elm, Davao). They unfairly skew the comparison since pros are faster than age groupers, so they're now filtered out alongside the existing world-championship exclusion.
2. **Stop clipping Y-axis labels.** Race-name labels are right-anchored SVG text in a fixed-width gutter, so long names (e.g. "Erkner Berlin-Brandenburg") overflowed past the left edge and were hard-clipped. The gutter is widened and overlong names are truncated with an ellipsis; the full name still shows in the hover tooltip.

## Why

Reported by the user: the "Dallas-Little Elm - Pros" bar made the chart misleading, and several Y-axis labels were visibly cut off.

## Testing

- New red/green unit tests for the `isProCourse` and `truncateLabel` helpers in `chart-utils.test.ts`.
- Full suite passes (132 tests); `npm run lint` clean.
- Verified in a browser: no Pros bars, no clipped labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pro-only courses are now filtered out from course charts
  * Course name labels in bar charts are now truncated for improved readability and proper layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->