### PR TITLE
fix: clarify discipline badges with Top X% convention and sync to toggle

### DIFF
--- a/app/src/components/DisciplineSections.tsx
+++ b/app/src/components/DisciplineSections.tsx
@@ -2,7 +2,9 @@
 
 import { useState } from "react";
 import DisciplineSection from "./DisciplineSection";
+import PercentilePill from "./PercentilePill";
 import { HistogramData } from "@/lib/types";
+import { DISCIPLINE_COLORS, DEFAULT_DISCIPLINE_COLOR } from "@/lib/colors";
 
 export interface DisciplineData {
   key: string;
@@ -20,9 +22,33 @@ interface Props {
 
 export default function DisciplineSections({ disciplines, transitions, ageGroup }: Props) {
   const [showOverall, setShowOverall] = useState(false);
+  const scopeLabel = showOverall ? "overall field" : "age group";
 
   return (
     <div className="space-y-6">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {disciplines.map((d) => (
+          <div
+            key={d.key}
+            className="relative bg-gray-900 rounded-lg border border-gray-700 p-4 text-center"
+          >
+            <div className="absolute top-2 right-2">
+              <PercentilePill
+                percentile={(showOverall ? d.overall : d.ageGroup).athletePercentile}
+                scopeLabel={scopeLabel}
+              />
+            </div>
+            <div
+              className="text-sm font-medium mb-1"
+              style={{ color: DISCIPLINE_COLORS[d.label] || DEFAULT_DISCIPLINE_COLOR }}
+            >
+              {d.label}
+            </div>
+            <div className="text-lg font-mono font-bold text-white">{d.time}</div>
+          </div>
+        ))}
+      </div>
+
       <div className="flex items-center justify-center">
         <div className="inline-flex rounded-lg bg-gray-800 p-1">
           <button

--- a/app/src/components/HistogramSection.tsx
+++ b/app/src/components/HistogramSection.tsx
@@ -5,8 +5,6 @@ import {
   type Discipline,
 } from "@/lib/data";
 import type { AthleteResult } from "@/lib/types";
-import { DISCIPLINE_COLORS, DEFAULT_DISCIPLINE_COLOR } from "@/lib/colors";
-import PercentilePill from "./PercentilePill";
 
 const DisciplineSections = dynamic(() => import("./DisciplineSections"));
 
@@ -45,33 +43,11 @@ export default async function HistogramSection({ slug, athlete }: Props) {
   }));
 
   return (
-    <>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-        {histograms.map((d) => (
-          <div
-            key={d.key}
-            className="relative bg-gray-900 rounded-lg border border-gray-700 p-4 text-center"
-          >
-            <div className="absolute top-2 right-2">
-              <PercentilePill percentile={d.ageGroup.athletePercentile} />
-            </div>
-            <div
-              className="text-sm font-medium mb-1"
-              style={{ color: DISCIPLINE_COLORS[d.label] || DEFAULT_DISCIPLINE_COLOR }}
-            >
-              {d.label}
-            </div>
-            <div className="text-lg font-mono font-bold text-white">{d.time}</div>
-          </div>
-        ))}
-      </div>
-
-      <DisciplineSections
-        disciplines={histograms}
-        transitions={transitionHistograms}
-        ageGroup={athlete.ageGroup}
-      />
-    </>
+    <DisciplineSections
+      disciplines={histograms}
+      transitions={transitionHistograms}
+      ageGroup={athlete.ageGroup}
+    />
   );
 }
 

--- a/app/src/components/PercentilePill.tsx
+++ b/app/src/components/PercentilePill.tsx
@@ -1,21 +1,24 @@
-import { formatPercentile } from "@/lib/percentile";
+import { formatTopPercent } from "@/lib/percentile";
 
 interface PercentilePillProps {
   /** Raw percentile value (share of field beaten, 0-100); 0 means no data. */
   percentile: number;
-  /** Optional tooltip/aria-label override; defaults to "Faster than X% of age group". */
+  /** Which field the percentile is measured against, e.g. "age group" or "overall field". */
+  scopeLabel: string;
+  /** Optional tooltip/aria-label override; defaults to "Top X% of <scopeLabel>". */
   label?: string;
 }
 
 /**
- * Small amber pill showing the share of the athlete's age group they beat for a
- * discipline (higher is better). Note this is the opposite convention from the
- * "Top X%" summary cards, so the tooltip spells out the meaning.
+ * Small amber pill showing the athlete's rank-from-top for a discipline, using the
+ * same "Top X%" convention as the summary cards (lower is better). The tooltip
+ * names the comparison field so it always matches the active age group / overall
+ * field toggle.
  */
-export default function PercentilePill({ percentile, label }: PercentilePillProps) {
-  const text = formatPercentile(percentile);
+export default function PercentilePill({ percentile, scopeLabel, label }: PercentilePillProps) {
+  const text = formatTopPercent(percentile);
   const description =
-    label ?? (text === "—" ? "Percentile unavailable" : `Faster than ${text} of age group`);
+    label ?? (text === "—" ? "Percentile unavailable" : `${text} of ${scopeLabel}`);
   return (
     <span
       className="inline-flex items-center px-1.5 py-0.5 text-[10px] font-bold rounded-full bg-amber-400/15 text-amber-400 tabular-nums"

--- a/app/src/lib/__tests__/percentile.test.ts
+++ b/app/src/lib/__tests__/percentile.test.ts
@@ -1,45 +1,40 @@
 import { describe, it, expect } from "vitest";
-import { formatPercentile } from "../percentile";
+import { formatTopPercent } from "../percentile";
 
-describe("formatPercentile", () => {
-  it("formats a normal percentile with a percent sign", () => {
-    expect(formatPercentile(22)).toBe("22%");
-    expect(formatPercentile(1)).toBe("1%");
-    expect(formatPercentile(99)).toBe("99%");
-    expect(formatPercentile(88)).toBe("88%");
+describe("formatTopPercent", () => {
+  it("converts share-beaten into the rank-from-top convention", () => {
+    // Beat 37% of the field => 63% finished ahead => Top 63%.
+    expect(formatTopPercent(37)).toBe("Top 63%");
+    expect(formatTopPercent(50)).toBe("Top 50%");
+    expect(formatTopPercent(71)).toBe("Top 29%");
   });
 
-  it("rounds fractional percentiles", () => {
-    expect(formatPercentile(87.6)).toBe("88%");
-    expect(formatPercentile(88.4)).toBe("88%");
+  it("rounds fractional values", () => {
+    expect(formatTopPercent(37.4)).toBe("Top 63%");
+    expect(formatTopPercent(37.6)).toBe("Top 62%");
   });
 
-  it("caps the winner at >99% instead of an impossible 100%", () => {
-    // e.g. Hamburg winner: beat 2177 of 2178 = 99.954% — must not round to 100%
-    expect(formatPercentile((2177 / 2178) * 100)).toBe(">99%");
-    expect(formatPercentile(99.6)).toBe(">99%");
-    expect(formatPercentile(100)).toBe(">99%");
+  it("clamps the winner to Top 1% instead of Top 0%", () => {
+    // Hamburg winner: beat 2177 of 2178 = 99.954% => Top 0.05% => clamp to Top 1%.
+    expect(formatTopPercent((2177 / 2178) * 100)).toBe("Top 1%");
+    expect(formatTopPercent(99.6)).toBe("Top 1%");
+    expect(formatTopPercent(100)).toBe("Top 1%");
   });
 
-  it("shows <1% at the bottom end instead of 0%", () => {
-    // e.g. second-to-last: beat 1 of 300 = 0.33% — must not round to 0%
-    expect(formatPercentile((1 / 300) * 100)).toBe("<1%");
-    expect(formatPercentile(0.4)).toBe("<1%");
-  });
-
-  it("does not cap values that round inside 1-99", () => {
-    expect(formatPercentile(99.4)).toBe("99%");
-    expect(formatPercentile(0.5)).toBe("1%");
+  it("clamps a near-last finisher to Top 99% instead of Top 100%", () => {
+    // Second-to-last: beat 1 of 300 = 0.33% => Top 99.67% => clamp to Top 99%.
+    expect(formatTopPercent((1 / 300) * 100)).toBe("Top 99%");
+    expect(formatTopPercent(0.4)).toBe("Top 99%");
   });
 
   it("renders an em-dash for 0 (treated as no data)", () => {
-    expect(formatPercentile(0)).toBe("—");
+    expect(formatTopPercent(0)).toBe("—");
   });
 
   it("renders an em-dash for negative, NaN, or Infinity", () => {
-    expect(formatPercentile(-5)).toBe("—");
-    expect(formatPercentile(Number.NaN)).toBe("—");
-    expect(formatPercentile(Number.POSITIVE_INFINITY)).toBe("—");
-    expect(formatPercentile(Number.NEGATIVE_INFINITY)).toBe("—");
+    expect(formatTopPercent(-5)).toBe("—");
+    expect(formatTopPercent(Number.NaN)).toBe("—");
+    expect(formatTopPercent(Number.POSITIVE_INFINITY)).toBe("—");
+    expect(formatTopPercent(Number.NEGATIVE_INFINITY)).toBe("—");
   });
 });

--- a/app/src/lib/percentile.ts
+++ b/app/src/lib/percentile.ts
@@ -1,19 +1,23 @@
 /**
- * Format a raw percentile value (as returned by getDisciplineHistogram) for UI display.
+ * Format a raw percentile value (as returned by getDisciplineHistogram) into a
+ * "Top X%" label for UI display.
  *
- * The value is the share of the field the athlete beat (higher is better) and may be
- * fractional. It is rounded here for display, but capped so the chip never shows an
- * impossible extreme: a race winner (e.g. 2177/2178 = 99.95%) renders as ">99%" rather
- * than "100%", and a back-of-pack finisher renders as "<1%" rather than "0%".
+ * The input is the share of the field the athlete beat (higher is better) and may
+ * be fractional. It is flipped to the rank-from-top convention used by the summary
+ * cards ("Top X%", where lower is better): an athlete who beat 37% of the field
+ * finished ahead of nobody else in the remaining 63%, so they are in the Top 63%.
  *
- * A value of 0 is treated as "no data available" because getDisciplineHistogram returns 0
- * when the histogram is missing or empty (a finisher who beat at least one athlete always
- * has a strictly positive value).
+ * The result is rounded and clamped to [1, 99] so the chip never shows an
+ * impossible extreme: a race winner (e.g. beat 2177/2178 = 99.95%) renders as
+ * "Top 1%" rather than "Top 0%", and a back-of-pack finisher renders as "Top 99%"
+ * rather than "Top 100%".
+ *
+ * An input of 0 is treated as "no data available" because getDisciplineHistogram
+ * returns 0 when the histogram is missing or empty (a finisher who beat at least
+ * one athlete always has a strictly positive value).
  */
-export function formatPercentile(percentile: number): string {
+export function formatTopPercent(percentile: number): string {
   if (!Number.isFinite(percentile) || percentile <= 0) return "—";
-  const rounded = Math.round(percentile);
-  if (rounded >= 100) return ">99%";
-  if (rounded < 1) return "<1%";
-  return `${rounded}%`;
+  const top = Math.min(99, Math.max(1, Math.round(100 - percentile)));
+  return `Top ${top}%`;
 }


### PR DESCRIPTION
## What

The amber badges on the discipline cards (Swim/Bike/Run/Total) showed a bare percentile (e.g. `37%`) that actually meant *"faster than 37% of the field"*. That was ambiguous on its own, used the **opposite** direction from the `Top X%` summary cards above, and always showed the **age-group** value even when "Overall Field" was selected.

## Change

- Badges now use the same `Top X%` convention as the summary cards (lower is better).
- Each badge carries a scope-aware tooltip (`Top 63% of overall field`).
- Badges sync with the Age Group / Overall Field toggle (the summary-cards row moved into the client component so it can read the toggle state).

## Verify

- New `formatTopPercent` unit tests (TDD); full suite green (157 tests).
- Manually confirmed in the running app: badges read `Top X%`, switch values with the toggle, and the Total badge matches the Overall summary card.

No tracked issue — this resolves user-reported confusion about what the badge percentage meant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added discipline cards that show each discipline’s color, time, and percentile at a glance.
  * Switched percentile display to a clearer “Top X%” format, with better fallback text when data is unavailable.

* **Bug Fixes**
  * Improved handling for invalid or missing percentile values by showing a dash instead of confusing numbers.
  * Updated percentile rounding and limits for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->