### PR TITLE
perf: render result pages dynamically to eliminate ISR write spend

### DIFF
--- a/app/src/app/race/[slug]/result/[id]/opengraph-image.tsx
+++ b/app/src/app/race/[slug]/result/[id]/opengraph-image.tsx
@@ -7,8 +7,12 @@ import { DISCIPLINE_COLORS } from "@/lib/colors";
 // Use Node runtime: getRaceBySlug / getAthleteById read from the filesystem.
 export const runtime = "nodejs";
 
-// Race results are static once scraped — cache the image for 1 day.
-export const revalidate = 86400;
+// Render on demand with no ISR caching. The daily revalidate billed an ISR
+// write every time a stale image was re-fetched, and with 75K+ result URLs
+// the long tail of share-preview crawlers meant writes vastly outnumbered
+// cache hits. A share burst only fetches the image a handful of times, so
+// regenerating it per request is cheaper than caching it.
+export const dynamic = "force-dynamic";
 
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";

--- a/app/src/app/race/[slug]/result/[id]/page.tsx
+++ b/app/src/app/race/[slug]/result/[id]/page.tsx
@@ -9,15 +9,13 @@ import { formatAthleteName } from "@/lib/format";
 import HistogramSection, { HistogramSectionFallback } from "@/components/HistogramSection";
 import ShareDialog from "@/components/ShareDialog";
 
-// Don't pre-render all 75K+ athlete pages at build time — generate on demand.
-// Next.js will render on first request and cache for subsequent visits.
-export async function generateStaticParams() {
-  return [];
-}
-
-// Race results are immutable once scraped — cache indefinitely. Cache is
-// reset on each deploy, which is when new CSVs land.
-export const revalidate = false;
+// Render dynamically instead of ISR. There are 75K+ result URLs and traffic
+// is a bot-driven long tail of unique paths: ISR wrote each first render to
+// the cache but the entries were almost never read back (observed ~2%
+// hit rate), so every crawl paid for a billed ISR write on top of the same
+// function invocation a dynamic render costs. Skipping the cache entirely
+// keeps per-request cost identical on misses and drops the write spend.
+export const dynamic = "force-dynamic";
 
 interface PageProps {
   params: Promise<{ slug: string; id: string }>;


### PR DESCRIPTION
## Why

Vercel usage for the last billing period showed **ISR Writes as the single biggest line item ($5.34, 1.33M writes)**, and the Observability ISR view attributes nearly all of it to `/race/[slug]/result/[id]` — 2.7K writes vs only **51 reads** in a 12h window, spread across 1.4K unique paths.

The route already had `revalidate = false`, so those writes weren't timer-based regeneration — they were **first-render cache writes from bots crawling the long tail of 75K+ unique result URLs**. Each crawl invoked the function (a cache miss) *and* paid for a billed ISR write that was almost never read back (~2% hit rate). Caching on this route is pure cost.

## What

- **`/race/[slug]/result/[id]/page.tsx`** — replace the empty `generateStaticParams` + `revalidate = false` with `export const dynamic = "force-dynamic"`. A cache miss already rendered per-request, so per-request cost is unchanged; the route just stops writing to the ISR cache entirely (writes → 0).
- **`/race/[slug]/result/[id]/opengraph-image.tsx`** — replace `revalidate = 86400` with `force-dynamic`. The daily revalidate billed a fresh ISR write every time a share-preview crawler re-fetched a stale image; a share burst only fetches the image a handful of times, so caching never paid for itself.

Expected impact: roughly the entire ISR Writes line item (~$5.34/period), traded for a small number of additional function invocations ($0.60/M vs ~$4/M for writes) on the tiny fraction of requests that were previously cache hits.

## Verification

- `npm run build` — `/race/[slug]/result/[id]` and its `opengraph-image` now build as `ƒ (Dynamic)` and are gone from the prerender manifest
- `npm run start` + curl — result page serves `Cache-Control: private, no-cache, no-store`; OG image serves `max-age=0, must-revalidate` (no `s-maxage`, so no ISR/CDN writes)
- 157/157 unit tests pass
- 4/5 e2e tests in `result-share-and-pills.spec.ts` pass (OG image PNG, og:image meta, share dialog). The 1 failure is pre-existing on `main`: the spec (from #182) expects pill text `67%` but #243 changed the convention to `Top 67%`.

## Not included (dashboard-side follow-ups)

The other big line items aren't fixable in code: Observability Events ($3.35) track raw request/log volume (there are no `console.log` calls in the app), and Web Analytics ($2.56) / Speed Insights ($0.65) are features you may want to keep. If further savings are needed: a Vercel WAF rule to challenge bot traffic on `/race/*/result/*`, and disabling Speed Insights or sampling Web Analytics from the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JGAEbFiTt3epNkmSH9d8i

---
_Generated by [Claude Code](https://claude.ai/code/session_018JGAEbFiTt3epNkmSH9d8i)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Race result pages now load fresh data on each visit instead of using cached or prebuilt content.
  * Open Graph images for race results are generated on demand, helping shared links reflect the latest information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->