### PR TITLE
feat: add per-page SEO metadata, structured data, and AI-search crawler access

### DIFF
--- a/app/src/app/athlete/[slug]/page.tsx
+++ b/app/src/app/athlete/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getAthleteProfile } from "@/lib/athlete-shards";
 import { getCountryFlagISO } from "@/lib/flags";
@@ -14,6 +15,26 @@ export const runtime = "edge";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
+}
+
+// The duplicate getAthleteProfile call (metadata + page) is served from the
+// in-memory shard cache, so it costs one shard fetch, not two.
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const profile = await getAthleteProfile(slug);
+  if (!profile) return {};
+
+  const name = formatAthleteName(profile.fullName);
+  const raceCount = profile.races.length;
+  const title = `${name} — Triathlon Race History`;
+  const description = `${name}${profile.country ? ` (${profile.country})` : ""} has ${raceCount} IRONMAN and IRONMAN 70.3 ${raceCount === 1 ? "result" : "results"} on TriTimes. View finish times, splits, and percentiles for every race.`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: `/athlete/${slug}` },
+    openGraph: { title, description, url: `/athlete/${slug}` },
+  };
 }
 
 export default async function AthletePage({ params }: PageProps) {

--- a/app/src/app/courses/page.tsx
+++ b/app/src/app/courses/page.tsx
@@ -2,9 +2,10 @@ import { getCourseStats } from "@/lib/data";
 import CourseCharts from "./course-charts";
 
 export const metadata = {
-  title: "Course Difficulty | TriTimes",
+  title: "IRONMAN & 70.3 Course Difficulty",
   description:
-    "Compare IRONMAN and IRONMAN 70.3 course difficulty based on median finish times across all race editions.",
+    "Which IRONMAN courses are fastest? Compare IRONMAN and IRONMAN 70.3 course difficulty based on median finish times across all race editions.",
+  alternates: { canonical: "/courses" },
 };
 
 export default function CoursesPage() {

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -18,9 +18,23 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "TriTimes — Triathlon Times",
+  metadataBase: new URL("https://tritimes.org"),
+  title: {
+    default: "TriTimes — IRONMAN & 70.3 Triathlon Results",
+    template: "%s | TriTimes",
+  },
   description:
-    "View your IronMan 70.3 triathlon results with statistical distributions for swim, bike, run, and total time.",
+    "Look up IRONMAN and IRONMAN 70.3 race results with full-field time distributions. See your percentile for swim, bike, run, and overall across 1,400+ races since 2002.",
+  openGraph: {
+    siteName: "TriTimes",
+    type: "website",
+    url: "https://tritimes.org",
+  },
+  // Set GOOGLE_SITE_VERIFICATION in Vercel to verify the site in Google
+  // Search Console without committing the token.
+  verification: {
+    google: process.env.GOOGLE_SITE_VERIFICATION,
+  },
 };
 
 export default function RootLayout({

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,8 +1,21 @@
 import GlobalSearchBar from "@/components/GlobalSearchBar";
 
+const WEBSITE_JSON_LD = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "TriTimes",
+  url: "https://tritimes.org",
+  description:
+    "IRONMAN and IRONMAN 70.3 race results with full-field time distributions and percentiles for swim, bike, and run.",
+};
+
 export default function Home() {
   return (
     <main className="flex-1">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(WEBSITE_JSON_LD) }}
+      />
       {/* Hero section */}
       <section className="relative">
         {/* Background gradient */}

--- a/app/src/app/race/[slug]/page.tsx
+++ b/app/src/app/race/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { getRaceBySlug, getRaceStats } from "@/lib/data";
@@ -25,6 +26,23 @@ interface PageProps {
   params: Promise<{ slug: string }>;
 }
 
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const race = getRaceBySlug(slug);
+  if (!race) return {};
+
+  const location = getRaceLocation(race);
+  const title = `${race.name} — Results & Time Distributions`;
+  const description = `Full results for ${race.name}${location ? ` in ${location}` : ""}: ${race.finishers.toLocaleString()} finishers, fastest and median splits, and time distributions for swim, bike, and run.`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: `/race/${slug}` },
+    openGraph: { title, description, url: `/race/${slug}` },
+  };
+}
+
 function genderColor(gender: string): string {
   if (gender === "Male") return "#3b82f6";
   if (gender === "Female") return "#ec4899";
@@ -46,8 +64,24 @@ export default async function RacePage({ params }: PageProps) {
 
   const location = getRaceLocation(race);
 
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "SportsEvent",
+    name: race.name,
+    sport: "Triathlon",
+    eventStatus: "https://schema.org/EventScheduled",
+    ...(race.date ? { startDate: race.date } : {}),
+    ...(location ? { location: { "@type": "Place", name: location } } : {}),
+    url: `https://tritimes.org/race/${slug}`,
+  };
+
   return (
     <main className="max-w-6xl w-full mx-auto px-4 py-8">
+      <script
+        type="application/ld+json"
+        // Escape "<" so race names can never close the script tag early.
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
+      />
       <header className="mb-8">
         <h1 className="text-3xl font-bold text-white">{race.name}</h1>
         <p className="text-gray-400 mt-1">

--- a/app/src/app/race/[slug]/result/[id]/page.tsx
+++ b/app/src/app/race/[slug]/result/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import Link from "next/link";
@@ -19,6 +20,26 @@ export const dynamic = "force-dynamic";
 
 interface PageProps {
   params: Promise<{ slug: string; id: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug, id } = await params;
+  const race = getRaceBySlug(slug);
+  const athlete = race ? getAthleteById(slug, Number(id)) : null;
+  if (!race || !athlete) return {};
+
+  const name = formatAthleteName(athlete.fullName);
+  const title = `${name} — ${race.name} Result`;
+  const description = athlete.finishTime
+    ? `${name} finished ${race.name} in ${athlete.finishTime}${athlete.ageGroup ? ` (${athlete.ageGroup})` : ""}. Swim ${athlete.swimTime}, bike ${athlete.bikeTime}, run ${athlete.runTime}. See percentiles and full-field time distributions.`
+    : `${name}'s result at ${race.name}. See splits, percentiles, and full-field time distributions.`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: `/race/${slug}/result/${id}` },
+    openGraph: { title, description, url: `/race/${slug}/result/${id}` },
+  };
 }
 
 export default async function ResultPage({ params }: PageProps) {

--- a/app/src/app/races/page.tsx
+++ b/app/src/app/races/page.tsx
@@ -1,7 +1,20 @@
-import { getRaces } from "@/lib/races";
+import type { Metadata } from "next";
+import { getRaces, getGlobalStats } from "@/lib/races";
 import RaceList from "./race-list";
 
 export const revalidate = false;
+
+export function generateMetadata(): Metadata {
+  const { raceCount, totalResults } = getGlobalStats();
+  const description = `Browse ${raceCount.toLocaleString()} IRONMAN and IRONMAN 70.3 races with ${totalResults.toLocaleString()} finisher results. Filter by distance and year, then dive into time distributions for any race.`;
+
+  return {
+    title: "All IRONMAN & 70.3 Races",
+    description,
+    alternates: { canonical: "/races" },
+    openGraph: { title: "All IRONMAN & 70.3 Races", description, url: "/races" },
+  };
+}
 
 export default function RacesPage() {
   const races = getRaces();

--- a/app/src/app/robots.ts
+++ b/app/src/app/robots.ts
@@ -2,17 +2,20 @@ import type { MetadataRoute } from "next";
 
 const SITE_URL = "https://tritimes.org";
 
-// AI training crawlers that have produced spikes of unique-URL traffic on
-// data-heavy sites. Blocking them keeps ISR writes bounded and the site's
+// AI *training* crawlers that have produced spikes of unique-URL traffic on
+// data-heavy sites. Blocking them keeps render spend bounded and the site's
 // content out of unattributed model training corpora.
+//
+// Deliberately NOT blocked: AI *search* and user-triggered agents
+// (OAI-SearchBot, ChatGPT-User, PerplexityBot, Claude-Web). They power cited
+// answers in ChatGPT Search / Perplexity — a referral channel, not a training
+// corpus — and their fetch volume is demand-driven rather than a full-graph
+// crawl. Result pages render dynamically with no ISR-write cost, so the
+// original spend concern no longer applies to them.
 const BLOCKED_AI_AGENTS = [
   "GPTBot",
-  "ChatGPT-User",
-  "OAI-SearchBot",
   "ClaudeBot",
   "anthropic-ai",
-  "Claude-Web",
-  "PerplexityBot",
   "CCBot",
   "Bytespider",
   "Amazonbot",

--- a/app/src/app/stats/page.tsx
+++ b/app/src/app/stats/page.tsx
@@ -4,9 +4,10 @@ import { getCountryFlagISO } from "@/lib/flags";
 import { formatAthleteName } from "@/lib/format";
 
 export const metadata = {
-  title: "Stats | TriTimes",
+  title: "IRONMAN & 70.3 Stats",
   description:
-    "Aggregate statistics across all IRONMAN and IRONMAN 70.3 races tracked by TriTimes.",
+    "Aggregate statistics across all IRONMAN and IRONMAN 70.3 races tracked by TriTimes: participation trends, finish times, and standout performances.",
+  alternates: { canonical: "/stats" },
 };
 
 function formatSeconds(seconds: number): string {


### PR DESCRIPTION
## Summary

Every page except `/stats` and `/courses` previously fell back to the layout's generic title and description, so all 1,472 sitemap'd race pages looked like duplicate pages to search engines. This PR implements the SEO foundation (P0) items:

- **Per-page metadata**: `generateMetadata` on race, result, athlete, and `/races` pages with unique titles, descriptions, and canonical URLs
- **Layout defaults**: `metadataBase`, a `%s | TriTimes` title template, OpenGraph `siteName`/`url` defaults, and optional Search Console verification via a `GOOGLE_SITE_VERIFICATION` env var (no tag emitted when unset)
- **Structured data**: `SportsEvent` JSON-LD on race pages, `WebSite` JSON-LD on the homepage
- **robots.ts**: unblock AI *search* / user-triggered crawlers (OAI-SearchBot, ChatGPT-User, PerplexityBot, Claude-Web) since they drive cited referrals and result pages no longer incur ISR write cost; training crawlers (GPTBot, ClaudeBot, CCBot, etc.) stay blocked
- Retitle `/stats` and `/courses` to fit the new title template and add canonical URLs

## Testing

- `npm run test`: 157/157 pass (including `import-graph.test.ts` — `/races` still imports only `races.ts`)
- `npm run lint`: clean
- `npm run build`: green; all routes keep their intended rendering strategy (race pages SSG-on-demand, result/athlete pages dynamic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DM6tEZaDCx5PQgaxuV8Fh8

---
_Generated by [Claude Code](https://claude.ai/code/session_01DM6tEZaDCx5PQgaxuV8Fh8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added richer page titles, descriptions, canonical URLs, and social sharing metadata across athlete, race, result, courses, races, stats, and site pages.
  - Added structured data for the website and race events to improve how pages appear in search results.
  - Added Google site verification support.
- **Updates**
  - Revised crawler access rules for selected AI bots.
  - Updated courses and stats page descriptions to better reflect their content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->