### PR TITLE
fix: render course pages dynamically to avoid production 500

### DIFF
--- a/app/src/app/courses/[course]/page.tsx
+++ b/app/src/app/courses/[course]/page.tsx
@@ -18,12 +18,11 @@ import ResultCard from "@/components/ResultCard";
 import RaceDistributions from "@/components/RaceDistributions";
 import { DISCIPLINE_COLORS } from "@/lib/colors";
 
-// Generate on demand — 178 courses, but keep parity with /race/[slug].
-export async function generateStaticParams() {
-  return [];
-}
-
-export const revalidate = false;
+// This page reads searchParams (?year=), which requires request-time rendering.
+// A statically-generated route (generateStaticParams + revalidate=false, as
+// /race/[slug] uses) throws DYNAMIC_SERVER_USAGE when it touches searchParams,
+// so this route opts into dynamic rendering instead.
+export const dynamic = "force-dynamic";
 
 interface PageProps {
   params: Promise<{ course: string }>;


### PR DESCRIPTION
## Motivation

Every `/courses/[course]` page (added in #259) returned a **500** in production — e.g. `https://www.tritimes.org/courses/im703-melbourne`.

## Root cause

The page reads `searchParams` (`?year=`) but declared the static-generation config (`generateStaticParams` + `revalidate = false`) copied from `/race/[slug]`. Touching `searchParams` in a statically-generated route throws `DYNAMIC_SERVER_USAGE` at request time, 500ing the page. Dev masked it (dev always renders dynamically); only the production build (which classified the route `● SSG`) failed. `/race/[slug]` is unaffected because it never reads `searchParams`.

## Fix

Opt the route into dynamic rendering (`export const dynamic = "force-dynamic"`) instead of static generation, since it must be request-time to read `?year=`. The route now builds as `ƒ (Dynamic)`.

## Testing

Reproduced and verified in **production mode** (`npm run build && npm start`), which is what CI/dev missed:
- Before: all `/courses/[course]` → 500 (`DYNAMIC_SERVER_USAGE`).
- After: melbourne/swansea combined → 200, `?year=2023` → 200, nonexistent course/year → 404, zero server-render errors.

Note: CI runs `npm run build` (which succeeds even with the bug, since the error is request-time) but not a production-mode smoke test, so neither CI nor the dev-mode Playwright e2e caught this. Documented the invariant in a code comment to prevent reverting to the static config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
