### PR TITLE
fix: switch course year tags without piling up browser history

### DIFF
--- a/app/e2e/course-year-history.spec.ts
+++ b/app/e2e/course-year-history.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+
+// A course with many editions. Switching between year tags on a course page
+// updates the URL (so a year is directly linkable) but should NOT stack a new
+// browser-history entry per click — otherwise returning to the previous page
+// requires as many Back clicks as years viewed.
+const COURSE = "im703-oceanside";
+
+test("switching year tags does not pile up browser history", async ({ page }) => {
+  // Arrive at the course page from the courses overview so there is a real
+  // previous page ("the race list") to return to.
+  await page.goto("/courses");
+  await page.locator(`a[href="/courses/${COURSE}"]`).first().click();
+  await page.waitForURL(new RegExp(`/courses/${COURSE}$`));
+
+  // Click through several year tags.
+  for (const year of ["2025", "2024", "2023"]) {
+    await page.locator(`a[href="/courses/${COURSE}?year=${year}"]`).click();
+    await page.waitForURL(new RegExp(`/courses/${COURSE}\\?year=${year}$`));
+  }
+
+  // A single Back should return to the courses overview, not step through the
+  // previously-viewed years.
+  await page.goBack();
+  await page.waitForURL(/\/courses$/);
+  expect(new URL(page.url()).pathname).toBe("/courses");
+});

--- a/app/src/app/courses/[course]/page.tsx
+++ b/app/src/app/courses/[course]/page.tsx
@@ -121,15 +121,18 @@ export default async function CoursePage({ params, searchParams }: PageProps) {
         </p>
       </header>
 
-      {/* Year tags */}
+      {/* Year tags. `replace` keeps the URL shareable while switching years
+          without stacking a browser-history entry per click, so one Back
+          returns to the previous page instead of stepping through each year. */}
       <div className="flex flex-wrap items-center gap-2 mb-8">
-        <Link href={`/courses/${course}`} className={`${tagBase} ${combined ? tagActive : tagIdle}`}>
+        <Link href={`/courses/${course}`} replace className={`${tagBase} ${combined ? tagActive : tagIdle}`}>
           All years
         </Link>
         {info.editions.map((e) => (
           <Link
             key={e.slug}
             href={`/courses/${course}?year=${e.year}`}
+            replace
             className={`${tagBase} ${selectedYear === e.year ? tagActive : tagIdle}`}
           >
             {e.year}


### PR DESCRIPTION
A Reddit commenter noted that on a course page (e.g. `/courses/im703-wisconsin`), clicking through the year tags stacks a browser-history entry per click, so returning to the previous page requires many Back clicks.

The year tags used `<Link>` with default push navigation. Adding `replace` keeps the URL shareable/bookmarkable while a year switch replaces the current history entry — so one Back returns to the previous page instead of stepping through each viewed year.

Added an e2e test (`e2e/course-year-history.spec.ts`) that clicks through several years and asserts a single Back returns to the courses overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bytmqtq2bNyot4PRvo8es7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated course year navigation so switching between editions does not add unnecessary browser-history entries.
  * Selecting “All years” or a specific year now lets you return directly to the previous page with one Back action.

* **Tests**
  * Added end-to-end coverage verifying the improved browser-history behavior when switching course years.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->